### PR TITLE
Fix unexpected non-local exits on Rubocop::AST::Node#parent_module_name

### DIFF
--- a/changelog/fix_fix_unexpected_nonlocal_exits_on_rubocop_ast_node_parent_module_name.md
+++ b/changelog/fix_fix_unexpected_nonlocal_exits_on_rubocop_ast_node_parent_module_name.md
@@ -1,0 +1,1 @@
+* [#176](https://github.com/rubocop-hq/rubocop-ast/pull/176): Fix unexpected non-local exits on  Rubocop::AST::Node#parent_module_name. ([@sanfrecce-osaka][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -317,7 +317,7 @@ module RuboCop
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)
         result    = ancestors.map do |ancestor|
-          parent_module_name_part(ancestor) { |full_name| return full_name }
+          parent_module_name_part(ancestor) { |full_name| break full_name }
         end.compact.reverse.join('::')
         result.empty? ? 'Object' : result
       end


### PR DESCRIPTION
With this PR, when Rubocop::AST::Node#parent_module_name_part is executed, it will no longer do non-local exits when a block is evaluated, and evaluating singleton_class or block in Rubocop::AST::Node#parent_module_name will behave as expected.
With this change, this PR aims to resolve the following issue.

https://github.com/rubocop/rubocop/issues/5022