### PR TITLE
Improve `parent_module_name`

### DIFF
--- a/changelog/fix_fix_unexpected_nonlocal_exits_on_rubocop_ast_node_parent_module_name.md
+++ b/changelog/fix_fix_unexpected_nonlocal_exits_on_rubocop_ast_node_parent_module_name.md
@@ -1,0 +1,1 @@
+* [#176](https://github.com/rubocop-hq/rubocop-ast/pull/176): Fix unexpected non-local exits on  Rubocop::AST::Node#parent_module_name. ([@sanfrecce-osaka][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -317,7 +317,7 @@ module RuboCop
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)
         result    = ancestors.map do |ancestor|
-          parent_module_name_part(ancestor) { |full_name| return full_name }
+          parent_module_name_part(ancestor) { |full_name| break full_name }
         end.compact.reverse.join('::')
         result.empty? ? 'Object' : result
       end

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -317,7 +317,7 @@ module RuboCop
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)
         result    = ancestors.map do |ancestor|
-          parent_module_name_part(ancestor) { |full_name| break full_name }
+          parent_module_name_part(ancestor) { |full_name| return full_name }
         end.compact.reverse.join('::')
         result.empty? ? 'Object' : result
       end
@@ -612,19 +612,17 @@ module RuboCop
       def parent_module_name_part(node)
         case node.type
         when :class, :module, :casgn
-          # TODO: if constant name has cbase (leading ::), then we don't need
-          # to keep traversing up through nested classes/modules
+          # TODO: if constant name has cbase (leading ::), then we must not
+          # keep traversing up through nested classes/modules
           node.defined_module_name
         when :sclass
-          yield parent_module_name_for_sclass(node)
+          parent_module_name_for_sclass(node)
         else # block
           parent_module_name_for_block(node) { yield nil }
         end
       end
 
       def parent_module_name_for_sclass(sclass_node)
-        # TODO: look for constant definition and see if it is nested
-        # inside a class or module
         subject = sclass_node.children[0]
 
         if subject.const_type?

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe RuboCop::AST::NodePattern do
     builder = RuboCop::AST::Builder.new
     Parser::CurrentRuby.new(builder).parse(buffer)
   end
-
   let(:root_node) { parse(ruby) }
   let(:node) { root_node }
   let(:params) { [] }

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -708,7 +708,22 @@ RSpec.describe RuboCop::AST::Node do
       end
 
       it { is_expected.to eq 'Foo::#<Class:Foo>::Bar' }
+    end
+
+    context 'when node nested in an unknown block' do
+      let(:src) do
+        <<~RUBY
+          module Foo
+            foo do
+              class Bar
+                >>attr_reader :config<<
+              end
+            end
+          end
+        RUBY
       end
+
+      it { is_expected.to eq nil }
     end
   end
 end

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::AST::Node do
-  let(:ast) { RuboCop::AST::ProcessedSource.new(src, ruby_version).ast }
+  let(:ast) { parse_source(src).node }
   let(:node) { ast }
 
   describe '#value_used?' do
@@ -661,27 +661,23 @@ RSpec.describe RuboCop::AST::Node do
   end
 
   describe '#parent_module_name' do
+    subject(:parent_module_name) { node.parent_module_name }
     context 'when node on top level' do
       let(:src) { 'def config; end' }
 
-      it 'returns "Object"' do
-        expect(node.parent_module_name).to eq 'Object'
-      end
+      it { is_expected.to eq 'Object' }
     end
 
     context 'when node on module' do
       let(:src) do
         <<~RUBY
           module Foo
-            attr_reader :config
+            >>attr_reader :config<<
           end
         RUBY
       end
 
-      it 'returns parent module name with namespaces' do
-        method_defined_node = node.children.last
-        expect(method_defined_node.parent_module_name).to eq 'Foo'
-      end
+      it { is_expected.to eq 'Foo' }
     end
 
     context 'when node on singleton class' do
@@ -689,16 +685,13 @@ RSpec.describe RuboCop::AST::Node do
         <<~RUBY
           module Foo
             class << self
-              attr_reader :config
+              >>attr_reader :config<<
             end
           end
         RUBY
       end
 
-      it 'returns parent module name with namespaces' do
-        method_defined_node = node.children.last.children.last.children.last
-        expect(method_defined_node.parent_module_name).to eq 'Foo::#<Class:Foo>'
-      end
+      it { is_expected.to eq 'Foo::#<Class:Foo>' }
     end
 
     context 'when node on class in singleton class' do
@@ -707,16 +700,14 @@ RSpec.describe RuboCop::AST::Node do
           module Foo
             class << self
               class Bar
-                attr_reader :config
+                >>attr_reader :config<<
               end
             end
           end
         RUBY
       end
 
-      it 'returns parent module name with namespaces' do
-        method_defined_node = node.children.last.children.last.children.last
-        expect(method_defined_node.parent_module_name).to eq 'Foo::#<Class:Foo>::Bar'
+      it { is_expected.to eq 'Foo::#<Class:Foo>::Bar' }
       end
     end
   end


### PR DESCRIPTION
This builds on #176 

@sanfrecce-osaka: first commit shows a way to simplify the tests

Second commit adds a test that would fail with your patch, and fixes that.

This still isn't quite right as the result with `duplicate_method` cop isn't quite right, and it gets confused between `Foo.method` and `Foo::#<Class:Foo>#method`.

I'm not sure if it's best to change the cop, or add an `Node` method for `qualified_name` or something.