### PR TITLE
Support `Parser::Ruby31`

### DIFF
--- a/changelog/new_support_ruby_3_1_parser.md
+++ b/changelog/new_support_ruby_3_1_parser.md
@@ -1,0 +1,1 @@
+* [#182](https://github.com/rubocop-hq/rubocop-ast/pull/182): Support `Parser::Ruby31` for Ruby 3.1 parser (experimental). ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -236,6 +236,9 @@ module RuboCop
         when 2.8, 3.0
           require 'parser/ruby30'
           Parser::Ruby30
+        when 3.1
+          require 'parser/ruby31'
+          Parser::Ruby31
         else
           raise ArgumentError,
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rubocop-hq/rubocop-ast/issues'
   }
 
-  s.add_runtime_dependency('parser', '>= 2.7.1.5')
+  s.add_runtime_dependency('parser', '>= 3.0.1.1')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ RSpec.shared_context 'ruby 3.0', :ruby30 do
   let(:ruby_version) { 3.0 }
 end
 
+RSpec.shared_context 'ruby 3.1', :ruby31 do
+  let(:ruby_version) { 3.1 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
Parser gem has been started development for Ruby 3.1 (edge Ruby).
https://github.com/whitequark/parser/pull/792

This PR supports `Parser::Ruby31`, the early adapters will be able to try edge Ruby with RuboCop.

And this PR update to require Parser 3.0.1.1 or higher, which contains `Parser::Ruby31`.
https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v3011-2021-05-02