### PR TITLE
Escape special chars in docs

### DIFF
--- a/changelog/change_escape_references_in_docs.md
+++ b/changelog/change_escape_references_in_docs.md
@@ -1,0 +1,1 @@
+* Escape References in Documentation, partially addressing https://github.com/rubocop/rubocop/issues/9150. ([@wcmonty][])

--- a/docs/modules/ROOT/pages/node_types.adoc
+++ b/docs/modules/ROOT/pages/node_types.adoc
@@ -99,10 +99,10 @@ The following fields are given when relevant to nodes in the source code:
 |defs|Singleton method definition (full format) - i.e. defining a method on a single object.|Four children. First child is the receiver; second child is the name of the method (symbol); third child is `args` or `forward_args` (only if `emit_forward` is false, and it's true by default), and the fourth child is a body statement.|def some_obj.foo(some_arg, kwarg: 1); end|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/DefNode[DefNode]
 
 |dstr|Interpolated string literal.|Children are split into `str` nodes, with interpolation represented by separate expression nodes.
-|`"foo#{bar}baz"`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
+|`"foo#\{bar\}baz"`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
 
 |dsym|Interpolated symbol literal.|Children are split into `str` nodes, with interpolation represented by separate expression nodes.
-|`:"foo#{bar}baz"`|N/A
+|`:"foo#\{bar\}baz"`|N/A
 
 |ensure|Block that contains an `ensure` along with possible `rescue`s. Must be inside a `def`, `defs`, `block` or `begin`.|The last child is the body statement of the `ensure` block. If there is a `rescue`, it is the first child (and contains the body statement of the top block); otherwise, the first child is the body statement of the top block.|begin; foo; rescue Exception; bar; ensure; baz; end|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/EnsureNode[EnsureNode]
 
@@ -180,10 +180,10 @@ The following fields are given when relevant to nodes in the source code:
 
 |redo|Redo command|None|redo|N/A
 
-|regexp|Regular expression literal.|Children are split into `str` nodes, with interpolation represented by separate expression nodes. The last child is a `regopt`.|/foo#{bar}56/|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/RegexpNode[RegexpNode]
+|regexp|Regular expression literal.|Children are split into `str` nodes, with interpolation represented by separate expression nodes. The last child is a `regopt`.|/foo#\{bar\}56/|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/RegexpNode[RegexpNode]
 
 |regopt|Regular expression option, appearing after a regexp literal (the "im" in the example).|A list of symbols representing the options (e.g. `:i` and `:m`)
-|/foo#{bar}/im|N/A
+|/foo#\{bar\}/im|N/A
 
 |resbody|Exception rescue. Always occurs inside a `rescue` node.|Three children. First child is either `nil` or an array of expression nodes representing the exceptions to rescue. Second child is `nil` or an assignment node representing the value to save the exception into. Last child is a body statement.|begin; rescue Exception, A => bar; 1; end|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/ResbodyNode[ResbodyNode]
 
@@ -225,7 +225,7 @@ a|`foo` or `foo.bar`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST
 
 |while-post|Loop with condition coming last.|Two children. First child is an expression node for condition, second child is a body statement.|begin; foo; end while condition|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/WhileNode[WhileNode]
 
-|xstr|Execute string (backticks). The heredoc version is treated totally differently from the regular version.|Children are split into `str` nodes, with interpolation represented by separate expression nodes .|`foo#{bar}`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
+|xstr|Execute string (backticks). The heredoc version is treated totally differently from the regular version.|Children are split into `str` nodes, with interpolation represented by separate expression nodes .|`foo#\{bar\}`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
 
 |yield|Yield to a block.|Children are expression nodes representing arguments.|yield(foo)|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/YieldNode[YieldNode]
 


### PR DESCRIPTION
When generating documentation `{bar}` in the documentation triggers a warning like:
```
asciidoctor: WARNING: skipping reference to missing attribute: bar
```

This is part of the the reason for [this issue](https://github.com/rubocop/rubocop/issues/9150) in the Rubocop repository (although there are other places that this can be seen in other Rubocop repositories).

To test:
```shell
# Generate documentation on current master
# We receive some warnings during generation
rubocop-ast git:(wm/escape_references_in_docs) > git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
rubocop-ast git:(master) > asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/node_types.adoc -o master.html
asciidoctor: WARNING: skipping reference to missing attribute: bar
asciidoctor: WARNING: skipping reference to missing attribute: bar
asciidoctor: WARNING: skipping reference to missing attribute: bar
asciidoctor: WARNING: skipping reference to missing attribute: bar
asciidoctor: WARNING: skipping reference to missing attribute: bar

# Generate documentation on the fix branch
rubocop-ast git:(master) > git checkout wm/escape_references_in_docs
Switched to branch 'wm/escape_references_in_docs'
Your branch is up to date with 'origin/wm/escape_references_in_docs'.
rubocop-ast git:(wm/escape_references_in_docs) > asciidoctor -a attribute-missing=warn docs/modules/ROOT/pages/node_types.adoc -o escaped.html

# We can see that the only difference between the generated files is the timestamp
rubocop-ast git:(wm/escape_references_in_docs) > diff master.html escaped.html
1601c1601
< Last updated 2021-07-02 12:39:33 -0400
---
> Last updated 2021-07-02 12:39:46 -0400
```
  