### PR TITLE
Suppress RuboCop 1.8's new offense

### DIFF
--- a/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
@@ -347,7 +347,7 @@ module RuboCop
           def compile_loop_advance(to = '+=1')
             # The `#{@cur_child_var} ||` is just to avoid unused variable warning
             "(#{@cur_child_var} = #{@seq_var}.children[#{@cur_index_var} #{to}]; " \
-            "#{@cur_child_var} || true)"
+              "#{@cur_child_var} || true)"
           end
 
           def compile_loop(term)

--- a/lib/rubocop/ast/node_pattern/parser.rb
+++ b/lib/rubocop/ast/node_pattern/parser.rb
@@ -52,7 +52,7 @@ module RuboCop
 
           detail = node.loc&.expression&.source || node.to_s
           raise NodePattern::Invalid, 'parse error, expected unary node pattern ' \
-            "but got expression matching multiple elements: #{detail}"
+                                      "but got expression matching multiple elements: #{detail}"
         end
 
         # Overrides Racc::Parser's method:

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -945,7 +945,7 @@ RSpec.describe RuboCop::AST::NodePattern do
     context 'with complex nesting' do
       let(:pattern) do
         '{(send {$int $float} {$:inc $:dec}) ' \
-        '[!nil {($_ sym $_) (send ($_ $_) :object_id)}]}'
+          '[!nil {($_ sym $_) (send ($_ $_) :object_id)}]}'
       end
       let(:ruby) { '10.object_id' }
       let(:captured_vals) { [:int, 10] }


### PR DESCRIPTION
This PR suppresses and auto-corrects the following RuboCop 1.8's new offense.

```console
% bundle exec rubocop -a
(snip)

Inspecting 3 files
CCC

Offenses:

lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb:350:13: C:
[Corrected] Layout/LineEndStringConcatenationIndentation: Indent the first part of a string concatenated with backslash.
"#{@cur_child_var} || true)"
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/ast/node_pattern/parser.rb:55:13: C: [Corrected]
Layout/LineEndStringConcatenationIndentation: Align parts of a string concatenated with backslash.
"but got expression matching multiple elements: #{detail}"
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/ast/node_pattern_spec.rb:948:9: C: [Corrected]
Layout/LineEndStringConcatenationIndentation: Indent the first part of a string concatenated with backslash.
'[!nil {($_ sym $_) (send ($_ $_) :object_id)}]}'
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

3 files inspected, 3 offenses detected, 3 offenses corrected
```