### PR TITLE
Fix `Layout/LeadingCommentSpace` offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - 'spec/rubocop/ast/node_pattern/parse_helper.rb'
     - 'spec/rubocop/ast/fixtures/*'
   TargetRubyVersion: 2.5
+  SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:
   Exclude:

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -80,23 +80,23 @@ module RuboCop
         "#<#{self.class} #{pattern}>"
       end
 
-      def marshal_load(pattern) #:nodoc:
+      def marshal_load(pattern) # :nodoc:
         initialize pattern
       end
 
-      def marshal_dump #:nodoc:
+      def marshal_dump # :nodoc:
         pattern
       end
 
-      def as_json(_options = nil) #:nodoc:
+      def as_json(_options = nil) # :nodoc:
         pattern
       end
 
-      def encode_with(coder) #:nodoc:
+      def encode_with(coder) # :nodoc:
         coder['pattern'] = pattern
       end
 
-      def init_with(coder) #:nodoc:
+      def init_with(coder) # :nodoc:
         initialize(coder['pattern'])
       end
 


### PR DESCRIPTION
`Layout/LeadingCommentSpace` was updated in rubocop/rubocop#9964 to consider `:nodoc:`