### PR TITLE
Move `ProcessedSource#sorted_tokens` to be a public method

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -177,6 +177,14 @@ module RuboCop
         sorted_tokens[last_token_index(range_or_node)]
       end
 
+      # The tokens list is always sorted by token position, except for cases when heredoc
+      # is passed as a method argument. In this case tokens are interleaved by
+      # heredoc contents' tokens.
+      def sorted_tokens
+        # Use stable sort.
+        @sorted_tokens ||= tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
+      end
+
       private
 
       def comment_index
@@ -270,14 +278,6 @@ module RuboCop
       def last_token_index(range_or_node)
         end_pos = source_range(range_or_node).end_pos
         sorted_tokens.bsearch_index { |token| token.end_pos >= end_pos }
-      end
-
-      # The tokens list is always sorted by token position, except for cases when heredoc
-      # is passed as a method argument. In this case tokens are interleaved by
-      # heredoc contents' tokens.
-      def sorted_tokens
-        # Use stable sort.
-        @sorted_tokens ||= tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
       end
 
       def source_range(range_or_node)


### PR DESCRIPTION
A number of cops are not detecting issues when looking at tokens around heredocs (for instance `Layout/SpaceInsideParams`) because they use pairs of tokens, but the tokens are not sorted properly for heredocs as method arguments (as per the comment of `ProcessedSource#sorted_tokens`).

For instance, this space is not detected by `Layout/SpaceInsideParams` currently because the tokens are not sorted in the expected order:

```ruby
foo(<<~STR )
  text
STR
```

This change just moves that method to be public so that the cops can use it.