### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New features
 
-* [#x](https://github.com/rubocop-hq/rubocop-ast/pull/x): Move `ProcessedSource#sorted_tokens` to be a public method. ([@dvandersluis][])
+* [#195](https://github.com/rubocop-hq/rubocop-ast/pull/x): Move `ProcessedSource#sorted_tokens` to be a public method. ([@dvandersluis][])
 
 ## 1.8.0 (2021-07-14)
 


### PR DESCRIPTION
Incorrect PR number

Also seems CHANGELOG didn't have newline at last it and GitHub web editor added it