### PR TITLE
[Fix #184] Fix `Node#parent_module_name` for `sclass` nodes

### DIFF
--- a/changelog/fix_fix_184_fix_nodeparent_module_name_for.md
+++ b/changelog/fix_fix_184_fix_nodeparent_module_name_for.md
@@ -1,0 +1,1 @@
+* [#197](https://github.com/rubocop-hq/rubocop-ast/pull/197): [Fix #184] Fix `Node#parent_module_name` for `sclass` nodes. ([@dvandersluis][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -317,7 +317,11 @@ module RuboCop
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)
         result    = ancestors.map do |ancestor|
-          parent_module_name_part(ancestor) { |full_name| return full_name }
+          parent_module_name_part(ancestor) do |full_name|
+            return nil unless full_name
+
+            full_name
+          end
         end.compact.reverse.join('::')
         result.empty? ? 'Object' : result
       end


### PR DESCRIPTION
Continuation of #177. I took @marcandre's tests and got them to pass. This fixes rubocop/rubocop#5022, but rubocop itself needs a PR as well because this change adds elements to the `parent_module_name` that it is not currently expecting. 