### PR TITLE
node.rb: fix typo in comment

### DIFF
--- a/lib/rubocop/ast/node_pattern/node.rb
+++ b/lib/rubocop/ast/node_pattern/node.rb
@@ -54,7 +54,7 @@ module RuboCop
           children_nodes.sum(&:nb_captures)
         end
 
-        # @return [Boolean] returns wether it matches a variable number of elements
+        # @return [Boolean] returns whether it matches a variable number of elements
         def variadic?
           arity.is_a?(Range)
         end


### PR DESCRIPTION
This PR fixes a tiny typo. 🧑‍🔧 