### PR TITLE
Suppress `Lint/AmbiguousOperatorPrecedence` offense

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -425,7 +425,7 @@ module RuboCop
       end
 
       def keyword?
-        return true if special_keyword? || send_type? && prefix_not?
+        return true if special_keyword? || (send_type? && prefix_not?)
         return false unless KEYWORDS.include?(type)
 
         !OPERATOR_KEYWORDS.include?(type) || loc.operator.is?(type.to_s)

--- a/spec/rubocop/ast/node_pattern/lexer_spec.rb
+++ b/spec/rubocop/ast/node_pattern/lexer_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::AST::NodePattern::Lexer do
 
     it 'distinguishes them' do
       types = tokens.map(&:first)
-      expect(types).to eq [:tNODE_TYPE] * 2 + [:tPARAM_CONST] * 7
+      expect(types).to eq ([:tNODE_TYPE] * 2) + ([:tPARAM_CONST] * 7)
       zz, percent_zz = tokens.last(2).map(&:last).map(&:first)
       expect(zz).to eq 'Zz'
       expect(percent_zz).to eq 'Zz'


### PR DESCRIPTION
This PR suppresses the following `Lint/AmbiguousOperatorPrecedence` offense.

```console
% bundle exec rake
(snip)

Offenses:

lib/rubocop/ast/node.rb:428:44: W: [Correctable]
Lint/AmbiguousOperatorPrecedence: Wrap expressions with varying
precedence with parentheses to avoid ambiguity.
return true if special_keyword? || send_type? && prefix_not?
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/ast/node_pattern/lexer_spec.rb:70:27: W: [Correctable]
Lint/AmbiguousOperatorPrecedence: Wrap expressions with varying
precedence with parentheses to avoid ambiguity.
expect(types).to eq [:tNODE_TYPE] * 2 + [:tPARAM_CONST] * 7
                    ^^^^^^^^^^^^^^^^^
spec/rubocop/ast/node_pattern/lexer_spec.rb:70:47: W: [Correctable]
Lint/AmbiguousOperatorPrecedence: Wrap expressions with varying
precedence with parentheses to avoid ambiguity.
expect(types).to eq [:tNODE_TYPE] * 2 + [:tPARAM_CONST] * 7
                                        ^^^^^^^^^^^^^^^^^^^

162 files inspected, 3 offenses detected, 3 offenses auto-correctable
```

https://github.com/rubocop/rubocop-ast/pull/206/checks?check_run_id=3501466011