### PR TITLE
[Fix #208] Update `MethodDispatchNode#block_literal?` to return true for `numblock`s

### DIFF
--- a/changelog/fix_fix_208_update.md
+++ b/changelog/fix_fix_208_update.md
@@ -1,0 +1,1 @@
+* [#208](https://github.com/rubocop/rubocop-ast/issues/208): Update `MethodDispatchNode#block_literal?` to return true for `numblock`s. ([@dvandersluis][])

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -28,9 +28,9 @@ module RuboCop
         node_parts[1]
       end
 
-      # The `block` node associated with this method dispatch, if any.
+      # The `block` or `numblock` node associated with this method dispatch, if any.
       #
-      # @return [BlockNode, nil] the `block` node associated with this method
+      # @return [BlockNode, nil] the `block` or `numblock` node associated with this method
       #                          call or `nil`
       def block_node
         parent if block_literal?
@@ -154,7 +154,7 @@ module RuboCop
       #
       # @return [Boolean] whether the dispatched method has a block
       def block_literal?
-        parent&.block_type? && eql?(parent.send_node)
+        (parent&.block_type? || parent&.numblock_type?) && eql?(parent.send_node)
       end
 
       # Checks whether this node is an arithmetic operation

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -1034,6 +1034,14 @@ RSpec.describe RuboCop::AST::SendNode do
 
       it { expect(send_node).not_to be_block_literal }
     end
+
+    context 'with Ruby >= 2.7', :ruby27 do
+      context 'with a numblock literal' do
+        let(:source) { '>> foo.bar << { baz(_1) }' }
+
+        it { expect(send_node).to be_block_literal }
+      end
+    end
   end
 
   describe '#arithmetic_operation?' do
@@ -1073,6 +1081,14 @@ RSpec.describe RuboCop::AST::SendNode do
       let(:source) { 'foo.bar' }
 
       it { expect(send_node.block_node).to be_nil }
+    end
+
+    context 'with Ruby >= 2.7', :ruby27 do
+      context 'with a numblock literal' do
+        let(:source) { '>>foo.bar<< { baz(_1) }' }
+
+        it { expect(send_node.block_node).to be_numblock_type }
+      end
     end
   end
 


### PR DESCRIPTION
If a send node has a numblock as a parent, `block_literal?` returns false, but this changes it to treat `numblock`s the same as regular `block`s. This also makes `send_node.block_node` return a `numblock` if applicable.

Fixes #208.