### PR TITLE
Make `Node#numeric_type?` aware of rational and complex literals

### DIFF
--- a/changelog/new_make_numeric_type_predicate_aware_of_rational_and_complex.md
+++ b/changelog/new_make_numeric_type_predicate_aware_of_rational_and_complex.md
@@ -1,0 +1,1 @@
+* [#213](https://github.com/rubocop/rubocop-ast/pull/213): Make `Node#numeric_type?` aware of rational and complex literals. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -464,7 +464,7 @@ module RuboCop
       end
 
       def numeric_type?
-        int_type? || float_type?
+        int_type? || float_type? || rational_type? || complex_type?
       end
 
       def range_type?

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -786,4 +786,54 @@ RSpec.describe RuboCop::AST::Node do
       it { is_expected.to eq nil }
     end
   end
+
+  describe '#nurimec_type?' do
+    context 'when integer literal' do
+      let(:src) { '42' }
+
+      it 'is true' do
+        expect(node).to be_numeric_type
+      end
+    end
+
+    context 'when float literal' do
+      let(:src) { '42.0' }
+
+      it 'is true' do
+        expect(node).to be_numeric_type
+      end
+    end
+
+    context 'when rational literal' do
+      let(:src) { '42r' }
+
+      it 'is true' do
+        expect(node).to be_numeric_type
+      end
+    end
+
+    context 'when complex literal' do
+      let(:src) { '42i' }
+
+      it 'is true' do
+        expect(node).to be_numeric_type
+      end
+    end
+
+    context 'when complex literal whose imaginary part is a rational' do
+      let(:src) { '42ri' }
+
+      it 'is true' do
+        expect(node).to be_numeric_type
+      end
+    end
+
+    context 'when string literal' do
+      let(:src) { '"42"' }
+
+      it 'is true' do
+        expect(node).not_to be_numeric_type
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR makes `Node#numeric_type?` aware of complex and rational literals.
These literals could be treated as numeric.

```ruby
42r.is_a?(Numeric)  # => true
42i.is_a?(Numeric)  # => true
42ri.is_a?(Numeric) # => true
```