### PR TITLE
Set `rubygems_mfa_required` in gemspec

### DIFF
--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/rubocop/rubocop-ast/blob/master/CHANGELOG.md',
     'source_code_uri' => 'https://github.com/rubocop/rubocop-ast/',
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-ast/',
-    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-ast/issues'
+    'bug_tracker_uri' => 'https://github.com/rubocop/rubocop-ast/issues',
+    'rubygems_mfa_required' => 'true'
   }
 
   s.add_runtime_dependency('parser', '>= 3.0.1.1')


### PR DESCRIPTION
Follows rubocop/rubocop#10239. Update gemspec to require MFA for privileged operations.