### PR TITLE
Support Ruby 3.1's anonymous block forwarding syntax

### DIFF
--- a/changelog/new_support_ruby31_anonymous_block_forwarding_syntax.md
+++ b/changelog/new_support_ruby31_anonymous_block_forwarding_syntax.md
@@ -1,0 +1,1 @@
+* [#218](https://github.com/rubocop/rubocop-ast/pull/218): Support Ruby 3.1's anonymous block forwarding syntax. ([@koic][])

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -91,11 +91,10 @@ module RuboCop
 
       many_symbol_children = %i[regopt]
 
-      node_child = %i[block_pass not
-                      match_current_line defined?
+      node_child = %i[not match_current_line defined?
                       arg_expr pin if_guard unless_guard
                       match_with_trailing_comma]
-      node_or_nil_child = %i[preexe postexe]
+      node_or_nil_child = %i[block_pass preexe postexe]
 
       NO_CHILD_NODES = (no_children + opt_symbol_child + literal_child).to_set.freeze
       private_constant :NO_CHILD_NODES # Used by Commissioner


### PR DESCRIPTION
Follow up to https://github.com/whitequark/parser/pull/833.

Here is a traditional block forwarding.

```console
% ruby-parse -e 'def foo(&b) = bar(&b)'
warning: parser/current is loading parser/ruby31, which recognizes
warning: 3.1.0-dev-compliant syntax, but you are running 3.1.0.
warning: please see
https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(def :foo
  (args
    (blockarg :b))
  (send nil :bar
    (block-pass
      (lvar :b))))
```

The anonymous block forwarding introduced in Ruby 3.1, the value of `block-pass` is nil.
So `block-pass` will have the possibility of having nil.

```console
% ruby-parse -e 'def foo(&) = bar(&)'
warning: parser/current is loading parser/ruby31, which recognizes
warning: 3.1.0-dev-compliant syntax, but you are running 3.1.0.
warning: please see
https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(def :foo
  (args
    (blockarg nil))
  (send nil :bar
    (block-pass nil)))
```

This PR prevents the following error that occur when anonymous block forwarding is used:

```console
% ruby -rrubocop-ast -e 'include RuboCop::AST::Traversal; walk(RuboCop::AST::ProcessedSource.new("def foo(&) = bar(&)", 3.1).ast)'
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:131:in
`on_block_pass': undefined method `type' for nil:NilClass (NoMethodError)
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:159:in
        `block in on_send'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
        `each'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
        `each_with_index'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:156:in
        `on_send'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:154:in
        `on_def'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rubocop-ast-1.13.0/lib/rubocop/ast/traversal.rb:20:in
        `walk'
        from -e:1:in `<main>'
```