### PR TITLE
Add `value_omission` method to `AST::PairNode`

### DIFF
--- a/changelog/new_add_value_omission_to_pair_node.md
+++ b/changelog/new_add_value_omission_to_pair_node.md
@@ -1,0 +1,1 @@
+* [#10219](https://github.com/rubocop/rubocop/pull/10219): Add `value_omission` method to `AST::PairNode` for Ruby 3.1's hash value omission. ([@koic][])

--- a/lib/rubocop/ast/node/pair_node.rb
+++ b/lib/rubocop/ast/node/pair_node.rb
@@ -62,6 +62,13 @@ module RuboCop
       def value_on_new_line?
         key.loc.line != value.loc.line
       end
+
+      # Checks whether the `pair` uses hash value omission.
+      #
+      # @return [Boolean] whether this `pair` uses hash value omission
+      def value_omission?
+        source.end_with?(':')
+      end
     end
   end
 end

--- a/spec/rubocop/ast/pair_node_spec.rb
+++ b/spec/rubocop/ast/pair_node_spec.rb
@@ -711,4 +711,18 @@ RSpec.describe RuboCop::AST::PairNode do
       end
     end
   end
+
+  describe '#value_omission?' do
+    context 'when using hash value omission', :ruby31 do
+      let(:source) { '{ x: }' }
+
+      it { expect(pair_node).to be_value_omission }
+    end
+
+    context 'when not using hash value omission' do
+      let(:source) { '{ x: x }' }
+
+      it { expect(pair_node).not_to be_value_omission }
+    end
+  end
 end


### PR DESCRIPTION
Follow up to https://github.com/whitequark/parser/pull/818

This PR adds `value_omission` method to `AST::PairNode` for Ruby 3.1's hash value omission.
It can replace string match with that named API.