### PR TITLE
Make `AST::Node#receiver` aware of `csend` block method calls

### DIFF
--- a/changelog/fix_make_node_receiver_aware_of_csend.md
+++ b/changelog/fix_make_node_receiver_aware_of_csend.md
@@ -1,0 +1,1 @@
+* [#10220](https://github.com/rubocop/rubocop/pull/10220): Make `AST::Node#receiver` aware of `csend` block method calls. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -274,7 +274,7 @@ module RuboCop
 
       # @!method receiver(node = self)
       def_node_matcher :receiver, <<~PATTERN
-        {(send $_ ...) ({block numblock} (send $_ ...) ...)}
+        {(send $_ ...) ({block numblock} (call $_ ...) ...)}
       PATTERN
 
       # @!method str_content(node = self)

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -288,4 +288,18 @@ RSpec.describe RuboCop::AST::BlockNode do
       it { is_expected.not_to be_void_context }
     end
   end
+
+  describe '#receiver' do
+    context 'with dot operator call' do
+      let(:source) { 'foo.bar { baz }' }
+
+      it { expect(block_node.receiver.source).to eq('foo') }
+    end
+
+    context 'with safe navigation operator call' do
+      let(:source) { 'foo&.bar { baz }' }
+
+      it { expect(block_node.receiver.source).to eq('foo') }
+    end
+  end
 end


### PR DESCRIPTION
Resolves: https://github.com/rubocop/rubocop/issues/10319.

This PR makes the following behavior of `send` calls and `csend` calls consistent.

Before:

- The receiver of `foo.bar { baz }` is `foo`.
- The receiver of `foo&.bar { baz }` is `nil`.

After:

- The receiver of `foo.bar { baz }` is `foo`.
- The receiver of `foo&.bar { baz }` is `foo`.