### PR TITLE
Support `Parser::Ruby32`

### DIFF
--- a/changelog/new_support_ruby_3_2_parser.md
+++ b/changelog/new_support_ruby_3_2_parser.md
@@ -1,0 +1,1 @@
+* [#223](https://github.com/rubocop-hq/rubocop-ast/pull/223): Support `Parser::Ruby32` for Ruby 3.2 parser (experimental). ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -226,7 +226,7 @@ module RuboCop
         [ast, comments, tokens]
       end
 
-      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       def parser_class(ruby_version)
         case ruby_version
         when 2.4
@@ -247,12 +247,15 @@ module RuboCop
         when 3.1
           require 'parser/ruby31'
           Parser::Ruby31
+        when 3.2
+          require 'parser/ruby32'
+          Parser::Ruby32
         else
           raise ArgumentError,
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"
         end
       end
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def create_parser(ruby_version)
         builder = RuboCop::AST::Builder.new

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('parser', '>= 3.0.1.1')
+  s.add_runtime_dependency('parser', '>= 3.1.1.0')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,10 @@ RSpec.shared_context 'ruby 3.1', :ruby31 do
   let(:ruby_version) { 3.1 }
 end
 
+RSpec.shared_context 'ruby 3.2', :ruby32 do
+  let(:ruby_version) { 3.2 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
Parser gem has been started development for Ruby 3.2 (edge Ruby).
https://github.com/whitequark/parser/pull/841

This PR supports `Parser::Ruby32`, the early adapters will be able to try edge Ruby with RuboCop.

And this PR update to require Parser 3.1.1.0 or higher, which contains `Parser::Ruby32`.
https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v3110-2022-02-21