### PR TITLE
Suppress RuboCop RSpec 2.9's warnings

### DIFF
--- a/spec/rubocop/ast/arg_node_spec.rb
+++ b/spec/rubocop/ast/arg_node_spec.rb
@@ -249,63 +249,63 @@ RSpec.describe RuboCop::AST::ArgNode do
     context 'with a regular argument' do
       let(:source) { 'def foo(x) end' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with a block' do
       let(:source) { 'foo { |x| x }' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with an optional argument' do
       let(:source) { 'def foo(x = 42) end' }
 
-      it { is_expected.to eq(true) }
+      it { is_expected.to be(true) }
     end
 
     context 'with an optional keyword argument' do
       let(:source) { 'def foo(x: 42) end' }
 
-      it { is_expected.to eq(true) }
+      it { is_expected.to be(true) }
     end
 
     context 'with a splatted argument' do
       let(:source) { 'def foo(*x) end' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with a double splatted argument' do
       let(:source) { 'def foo(**x) end' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with a block argument' do
       let(:source) { 'def foo(&x) end' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with a shadow argument' do
       let(:source) { 'foo { |; x| x = 5 }' }
 
-      it { is_expected.to eq(false) }
+      it { is_expected.to be(false) }
     end
 
     context 'with argument forwarding' do
       context 'with Ruby >= 2.7', :ruby27 do
         let(:source) { 'def foo(...); end' }
 
-        it { is_expected.to eq(false) } if RuboCop::AST::Builder.emit_forward_arg
+        it { is_expected.to be(false) } if RuboCop::AST::Builder.emit_forward_arg
       end
 
       context 'with Ruby >= 3.0', :ruby30 do
         let(:source) { 'def foo(x, ...); end' }
         let(:arg_node) { args_node.last }
 
-        it { is_expected.to eq(false) }
+        it { is_expected.to be(false) }
       end
     end
   end

--- a/spec/rubocop/ast/array_node_spec.rb
+++ b/spec/rubocop/ast/array_node_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::AST::ArrayNode do
         parse_source('foo = 1, 2, 3').ast.to_a.last
       end
 
-      it { expect(array_node.bracketed?).to be(nil) }
+      it { expect(array_node.bracketed?).to be_nil }
     end
   end
 end

--- a/spec/rubocop/ast/casgn_node_spec.rb
+++ b/spec/rubocop/ast/casgn_node_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::AST::CasgnNode do
     context 'when there is no parent' do
       let(:source) { 'VAR = value' }
 
-      it { is_expected.to eq(nil) }
+      it { is_expected.to be_nil }
     end
 
     context 'when the parent is a `cbase`' do

--- a/spec/rubocop/ast/class_node_spec.rb
+++ b/spec/rubocop/ast/class_node_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::AST::ClassNode do
         'class Foo; end'
       end
 
-      it { expect(class_node.parent_class).to be(nil) }
+      it { expect(class_node.parent_class).to be_nil }
     end
   end
 
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::AST::ClassNode do
         'class Foo; end'
       end
 
-      it { expect(class_node.body).to be(nil) }
+      it { expect(class_node.body).to be_nil }
     end
   end
 end

--- a/spec/rubocop/ast/defined_node_spec.rb
+++ b/spec/rubocop/ast/defined_node_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::AST::DefinedNode do
   describe '#receiver' do
     let(:source) { 'defined? :foo' }
 
-    it { expect(defined_node.receiver).to eq(nil) }
+    it { expect(defined_node.receiver).to be_nil }
   end
 
   describe '#method_name' do

--- a/spec/rubocop/ast/ext/set_spec.rb
+++ b/spec/rubocop/ast/ext/set_spec.rb
@@ -3,7 +3,7 @@
 # rubocop:disable RSpec/DescribeClass, Style/CaseEquality
 RSpec.describe 'Set#===' do
   it 'tests for inclusion' do
-    expect(Set[1, 2, 3] === 2).to eq true
+    expect(Set[1, 2, 3] === 2).to be true
   end
 end
 # rubocop:enable RSpec/DescribeClass, Style/CaseEquality

--- a/spec/rubocop/ast/lambda_node_spec.rb
+++ b/spec/rubocop/ast/lambda_node_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::AST::LambdaNode do
   let(:source) { '->(a, b) { a + b }' }
 
   describe '#receiver' do
-    it { expect(lambda_node.receiver).to eq nil }
+    it { expect(lambda_node.receiver).to be_nil }
   end
 
   describe '#method_name' do

--- a/spec/rubocop/ast/module_node_spec.rb
+++ b/spec/rubocop/ast/module_node_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::AST::ModuleNode do
         'module Foo; end'
       end
 
-      it { expect(module_node.body).to be(nil) }
+      it { expect(module_node.body).to be_nil }
     end
   end
 end

--- a/spec/rubocop/ast/node_pattern/helper.rb
+++ b/spec/rubocop/ast/node_pattern/helper.rb
@@ -12,7 +12,7 @@ module NodePatternHelper
   end
 
   def assert(test, mess = nil)
-    expect(test).to eq(true), *mess
+    expect(test).to be(true), *mess
   end
 
   def expect_parsing(ast, source, source_maps)

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::AST::NodePattern do
 
   shared_examples 'nonmatching' do
     it "doesn't match" do
-      expect(result).to be nil
+      expect(result).to be_nil
     end
   end
 
@@ -160,10 +160,10 @@ RSpec.describe RuboCop::AST::NodePattern do
       let(:pattern) { "  (send  42 \n :to_s ) " }
 
       it 'returns true iff the patterns are similar' do
-        expect(instance == instance.dup).to eq true
-        expect(instance == 42).to eq false
-        expect(instance == described_class.new('(send)')).to eq false
-        expect(instance == described_class.new('(send 42 :to_s)')).to eq true
+        expect(instance == instance.dup).to be true
+        expect(instance == 42).to be false
+        expect(instance == described_class.new('(send)')).to be false
+        expect(instance == described_class.new('(send 42 :to_s)')).to be true
       end
     end
   end

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -338,9 +338,9 @@ RSpec.describe RuboCop::AST::Node do
     let(:src) { '[0, 1, 2, 3, 4, 5]' }
 
     it 'returns trivial values for a root node' do
-      expect(node.sibling_index).to eq nil
-      expect(node.left_sibling).to eq nil
-      expect(node.right_sibling).to eq nil
+      expect(node.sibling_index).to be_nil
+      expect(node.left_sibling).to be_nil
+      expect(node.right_sibling).to be_nil
       expect(node.left_siblings).to eq []
       expect(node.right_siblings).to eq []
     end
@@ -363,8 +363,8 @@ RSpec.describe RuboCop::AST::Node do
 
       it 'returns the expected values' do
         expect(node.sibling_index).to eq 0
-        expect(node.left_sibling).to eq nil
-        expect(node.right_sibling).to eq nil
+        expect(node.left_sibling).to be_nil
+        expect(node.right_sibling).to be_nil
         expect(node.left_siblings.map(&:value)).to eq []
         expect(node.right_siblings.map(&:value)).to eq []
       end
@@ -412,7 +412,7 @@ RSpec.describe RuboCop::AST::Node do
       let(:src) { 'class Foo; a = 42; end' }
 
       it 'does not match' do
-        expect(node.class_constructor?).to eq(nil)
+        expect(node.class_constructor?).to be_nil
       end
     end
 
@@ -438,7 +438,7 @@ RSpec.describe RuboCop::AST::Node do
       let(:src) { 'Struct.new(:foo, :bar)' }
 
       it 'does not match' do
-        expect(node.struct_constructor?).to eq(nil)
+        expect(node.struct_constructor?).to be_nil
       end
     end
 
@@ -511,7 +511,7 @@ RSpec.describe RuboCop::AST::Node do
       let(:src) { 'Person = Struct.new(:name, :age)' }
 
       it 'does not match' do
-        expect(node.class_definition?).to eq(nil)
+        expect(node.class_definition?).to be_nil
       end
     end
 
@@ -769,7 +769,7 @@ RSpec.describe RuboCop::AST::Node do
         RUBY
       end
 
-      it { is_expected.to eq nil }
+      it { is_expected.to be_nil }
     end
 
     context 'when node nested in a class << exp' do
@@ -783,7 +783,7 @@ RSpec.describe RuboCop::AST::Node do
         RUBY
       end
 
-      it { is_expected.to eq nil }
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
           item.text == '# comment four'
         end
 
-        expect(comment).to eq nil
+        expect(comment).to be_nil
       end
     end
 
@@ -265,7 +265,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
 
       it 'returns nil if line has no comment' do
-        expect(processed_source.comment_at_line(3)).to be nil
+        expect(processed_source.comment_at_line(3)).to be_nil
       end
     end
 
@@ -369,7 +369,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       it 'yields nil when there is no match' do
         token = processed_source.find_token(&:right_bracket?)
 
-        expect(token).to eq nil
+        expect(token).to be_nil
       end
     end
   end

--- a/spec/rubocop/ast/resbody_node_spec.rb
+++ b/spec/rubocop/ast/resbody_node_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::AST::ResbodyNode do
     context 'when an exception variable is not given' do
       let(:source) { 'begin; beginbody; rescue; rescuebody; end' }
 
-      it { expect(resbody_node.exception_variable).to be(nil) }
+      it { expect(resbody_node.exception_variable).to be_nil }
     end
   end
 

--- a/spec/rubocop/ast/self_class_node_spec.rb
+++ b/spec/rubocop/ast/self_class_node_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::AST::SelfClassNode do
         'class << self; end'
       end
 
-      it { expect(self_class_node.body).to be(nil) }
+      it { expect(self_class_node.body).to be_nil }
     end
   end
 end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -818,7 +818,7 @@ RSpec.describe RuboCop::AST::SendNode do
         let(:source) { 'attr_reader' }
 
         it do
-          expect(send_node.attribute_accessor?).to be(nil)
+          expect(send_node.attribute_accessor?).to be_nil
         end
       end
     end

--- a/spec/rubocop/ast/token_spec.rb
+++ b/spec/rubocop/ast/token_spec.rb
@@ -107,8 +107,8 @@ RSpec.describe RuboCop::AST::Token do
     end
 
     it 'returns nil when there is not a space after token' do
-      expect(left_ref_bracket_token.space_after?).to be nil
-      expect(zero_token.space_after?).to be nil
+      expect(left_ref_bracket_token.space_after?).to be_nil
+      expect(zero_token.space_after?).to be_nil
     end
   end
 
@@ -131,12 +131,12 @@ RSpec.describe RuboCop::AST::Token do
     end
 
     it 'returns nil when there is not a space before token' do
-      expect(semicolon_token.space_before?).to be nil
-      expect(zero_token.space_before?).to be nil
+      expect(semicolon_token.space_before?).to be_nil
+      expect(zero_token.space_before?).to be_nil
     end
 
     it 'returns nil when it is on the first line' do
-      expect(processed_source.tokens[0].space_before?).to be nil
+      expect(processed_source.tokens[0].space_before?).to be_nil
     end
   end
 


### PR DESCRIPTION
This PR suppress new `RSpec/BeNil` and `RSpec/BeEq` cops warnings. e.g.:

```consle
% bundle exec rake
(snip)

spec/rubocop/ast/arg_node_spec.rb:308:29: C: [Corrected] RSpec/BeEq: Prefer be over eq.
it { is_expected.to eq(false) }
                    ^^
spec/rubocop/ast/array_node_spec.rb:111:45: C: [Corrected] RSpec/BeNil: Prefer be_nil over be(nil).
it { expect(array_node.bracketed?).to be(nil) }
                                      ^^^^^^^
```

cf. https://github.com/rubocop/rubocop-rspec/releases/tag/v2.9.0