### PR TITLE
Suppress RuboCop offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,14 +18,14 @@ gem 'rspec', '~> 3.7'
 # https://github.com/codeclimate/test-reporter/issues/418
 gem 'simplecov', '~> 0.10', '< 0.18'
 
-if ENV['RUBOCOP_VERSION'] == 'none'
+if ENV.fetch('RUBOCOP_VERSION', nil) == 'none'
   # Set this way on CI
   puts 'Running specs independently of RuboCop'
 else
   local_ast = File.expand_path('../rubocop', __dir__)
   if File.exist?(local_ast)
     gem 'rubocop', path: local_ast
-  elsif ENV['RUBOCOP_VERSION'] == 'master'
+  elsif ENV.fetch('RUBOCOP_VERSION', nil) == 'master'
     gem 'rubocop', git: 'https://github.com/rubocop/rubocop.git'
   else
     gem 'rubocop', '>= 1.0'

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -34,7 +34,7 @@ module RuboCop
 
         def def_callback(type, *signature,
                          arity: signature.size..signature.size,
-                         arity_check: ENV['RUBOCOP_DEBUG'] && self.arity_check(arity),
+                         arity_check: ENV.fetch('RUBOCOP_DEBUG', nil) && self.arity_check(arity),
                          body: self.body(signature, arity_check))
           type, *aliases = type
           lineno = caller_locations(1, 1).first.lineno


### PR DESCRIPTION
This PR suppresses the following RuboCop offenses.

```console
% bundle exec rake
(snip)

Offenses:

Gemfile:21:4: C: [Correctable] Style/FetchEnvVar:
Use ENV.fetch('RUBOCOP_VERSION') or ENV.fetch('RUBOCOP_VERSION', nil) instead of ENV['RUBOCOP_VERSION'].
if ENV['RUBOCOP_VERSION'] == 'none'
   ^^^^^^^^^^^^^^^^^^^^^^
Gemfile:28:9: C: [Correctable] Style/FetchEnvVar:
Use ENV.fetch('RUBOCOP_VERSION') or ENV.fetch('RUBOCOP_VERSION', nil) instead of ENV['RUBOCOP_VERSION'].
  elsif ENV['RUBOCOP_VERSION'] == 'master'
        ^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/ast/traversal.rb:37:39: C: [Correctable] Style/FetchEnvVar:
Use ENV.fetch('RUBOCOP_DEBUG') or ENV.fetch('RUBOCOP_DEBUG', nil) instead of ENV['RUBOCOP_DEBUG'].
                         arity_check: ENV['RUBOCOP_DEBUG'] && self.arity_check(arity),
                                      ^^^^^^^^^^^^^^^^^^^^

162 files inspected, 3 offenses detected, 3 offenses auto-correctable
```