### PR TITLE
Make `RegexpNode` aware of fixed-encoding regopt

### DIFF
--- a/changelog/fix_regexp_node_aware_of_fixed_encoding_regopt.md
+++ b/changelog/fix_regexp_node_aware_of_fixed_encoding_regopt.md
@@ -1,0 +1,1 @@
+* [#230](https://github.com/rubocop-hq/rubocop-ast/pull/230): Make `RegexpNode` aware of fixed-encoding regopt. ([@koic][])

--- a/lib/rubocop/ast/node/regexp_node.rb
+++ b/lib/rubocop/ast/node/regexp_node.rb
@@ -11,6 +11,7 @@ module RuboCop
         i: Regexp::IGNORECASE,
         m: Regexp::MULTILINE,
         n: Regexp::NOENCODING,
+        u: Regexp::FIXEDENCODING,
         o: 0
       }.freeze
       private_constant :OPTIONS
@@ -85,6 +86,11 @@ module RuboCop
       # @return [Bool] if regexp uses the no-encoding regopt
       def no_encoding?
         regopt_include?(:n)
+      end
+
+      # @return [Bool] if regexp uses the fixed-encoding regopt
+      def fixed_encoding?
+        regopt_include?(:u)
       end
 
       private

--- a/spec/rubocop/ast/regexp_node_spec.rb
+++ b/spec/rubocop/ast/regexp_node_spec.rb
@@ -53,6 +53,18 @@ RSpec.describe RuboCop::AST::RegexpNode do
 
       it { expect(regexp_node.to_regexp.inspect).to eq('/abc/i') }
     end
+
+    context 'with a regexp with an "n" option' do
+      let(:source) { '/abc/n' }
+
+      it { expect(regexp_node.to_regexp.inspect).to eq('/abc/n') }
+    end
+
+    context 'with a regexp with an "u" option' do
+      let(:source) { '/abc/u' }
+
+      it { expect(regexp_node.to_regexp.inspect).to eq('/abc/') }
+    end
   end
 
   describe '#regopt' do
@@ -487,6 +499,32 @@ RSpec.describe RuboCop::AST::RegexpNode do
       let(:source) { '/x/xnm' }
 
       it { is_expected.to be_no_encoding }
+    end
+  end
+
+  describe '#fixed_encoding?' do
+    context 'with no options' do
+      let(:source) { '/x/' }
+
+      it { is_expected.not_to be_fixed_encoding }
+    end
+
+    context 'with other options' do
+      let(:source) { '/x/xm' }
+
+      it { is_expected.not_to be_fixed_encoding }
+    end
+
+    context 'with only u option' do
+      let(:source) { '/x/u' }
+
+      it { is_expected.to be_fixed_encoding }
+    end
+
+    context 'with u and other options' do
+      let(:source) { '/x/unm' }
+
+      it { is_expected.to be_fixed_encoding }
     end
   end
 


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/issues/10552.

This PR makes `RegexpNode` aware of fixed-encoding regopt.