### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -24,13 +24,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu ]
-        ruby: [ 2.5, 2.6, 2.7, '3.0', 3.1, head ]
+        ruby: [ 2.6, 2.7, '3.0', 3.1, head ]
         coverage: [ null ]
         modern: [ null ]
         title: [ null ]
         include:
           - { os: windows, ruby: mingw }
-          - { ruby: 2.5, os: ubuntu, coverage: true, title: 'Coverage' }
+          - { ruby: 2.6, os: ubuntu, coverage: true, title: 'Coverage' }
           - { ruby: '3.0', os: ubuntu, modern: true, title: 'Specs "modern"' }
           # jruby disabled because of: https://github.com/jruby/jruby/issues/6416
           # - { ruby: jruby, os: ubuntu }
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu ]
-        ruby: [ 2.5, 2.7 ]
+        ruby: [ 2.6, 2.7 ]
         rubocop: [ master ]
         internal_investigation: [ null ]
         include:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'lib/rubocop/ast/node_pattern/lexer.rex.rb'
     - 'spec/rubocop/ast/node_pattern/parse_helper.rb'
     - 'spec/rubocop/ast/fixtures/*'
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
 
 InternalAffairs/NodeMatcherDirective:

--- a/changelog/change_drop_ruby_25.md
+++ b/changelog/change_drop_ruby_25.md
@@ -1,0 +1,1 @@
+* [#232](https://github.com/rubocop/rubocop-ast/pull/232): **(Breaking)** Drop support for Ruby 2.5. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -194,7 +194,7 @@ module RuboCop
       def right_siblings
         return [].freeze unless parent
 
-        parent.children[sibling_index + 1..-1].freeze
+        parent.children[sibling_index + 1..].freeze
       end
 
       # Common destructuring method. This can be used to normalize

--- a/lib/rubocop/ast/node/mixin/parameterized_node.rb
+++ b/lib/rubocop/ast/node/mixin/parameterized_node.rb
@@ -84,7 +84,7 @@ module RuboCop
         include ParameterizedNode
         # @return [Array<Node>] arguments, if any
         def arguments
-          children[first_argument_index..-1].freeze
+          children[first_argument_index..].freeze
         end
 
         # A shorthand for getting the first argument of the node.

--- a/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb
@@ -371,13 +371,13 @@ module RuboCop
 
           # @return [Hash] of {subcompiler => code}
           def compile_union_forks
-            compiler.each_union(node.children).map do |child|
+            compiler.each_union(node.children).to_h do |child|
               subsequence_terms = child.is_a?(Node::Subsequence) ? child.children : [child]
               fork = dup
               code = fork.compile_terms(subsequence_terms, @remaining_arity)
               @in_sync = false if @cur_index != :variadic_mode
               [fork, code]
-            end.to_h # we could avoid map if RUBY_VERSION >= 2.6...
+            end
           end
 
           # Modifies in place `forks` to insure that `cur_{child|index}_var` are ok

--- a/lib/rubocop/ast/node_pattern/node.rb
+++ b/lib/rubocop/ast/node_pattern/node.rb
@@ -116,7 +116,7 @@ module RuboCop
 
           def initialize(type, children = [], properties = {})
             if (replace = children.first.in_sequence_head)
-              children = [*replace, *children[1..-1]]
+              children = [*replace, *children[1..]]
             end
 
             super
@@ -130,7 +130,7 @@ module RuboCop
           end
 
           def arg_list
-            children[1..-1]
+            children[1..]
           end
         end
         FunctionCall = Predicate
@@ -212,7 +212,7 @@ module RuboCop
 
             return unless (replace = children.first.in_sequence_head)
 
-            [with(children: [*replace, *children[1..-1]])]
+            [with(children: [*replace, *children[1..]])]
           end
         end
 

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -162,7 +162,7 @@ module RuboCop
       ### generic processing of any other node (forward compatibility)
       defined = instance_methods(false)
                 .grep(/^on_/)
-                .map { |s| s.to_s[3..-1].to_sym } # :on_foo => :foo
+                .map { |s| s.to_s[3..].to_sym } # :on_foo => :foo
 
       to_define = ::Parser::Meta::NODE_TYPES.to_a
       to_define -= defined

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-ast'
   s.version = RuboCop::AST::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     RuboCop's Node and NodePattern classes.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10577.