### PR TITLE
Make parse from Ruby 1.9 to 2.3 available

### DIFF
--- a/changelog/new_make_parse_from_ruby_19_to_23_available.md
+++ b/changelog/new_make_parse_from_ruby_19_to_23_available.md
@@ -1,0 +1,1 @@
+* [#233](https://github.com/rubocop-hq/rubocop-ast/pull/233): Make parse from Ruby 1.9 to 2.3 available. ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -226,9 +226,24 @@ module RuboCop
         [ast, comments, tokens]
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
       def parser_class(ruby_version)
         case ruby_version
+        when 1.9
+          require 'parser/ruby19'
+          Parser::Ruby19
+        when 2.0
+          require 'parser/ruby20'
+          Parser::Ruby20
+        when 2.1
+          require 'parser/ruby21'
+          Parser::Ruby21
+        when 2.2
+          require 'parser/ruby22'
+          Parser::Ruby22
+        when 2.3
+          require 'parser/ruby23'
+          Parser::Ruby23
         when 2.4
           require 'parser/ruby24'
           Parser::Ruby24
@@ -255,7 +270,7 @@ module RuboCop
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"
         end
       end
-      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       def create_parser(ruby_version)
         builder = RuboCop::AST::Builder.new


### PR DESCRIPTION
RuboCop can analyze Ruby 1.9 or later. But now it turns out that RuboCop hasn't been able to parse older Ruby versions.
https://docs.rubocop.org/rubocop/1.29/compatibility.html#support-matrix

Analysis Ruby code and runtime Ruby versions are different. So, only runtime version should have been dropped.

This PR makes it possible to parse older Ruby versions that were accidentally dropped before RuboCop AST was separated from RuboCop core.

With this fix, the following recovery work will be possible.

- Recover for Ruby 2.5 analysis: https://github.com/rubocop/rubocop/pull/10626
- Recover for Ruby 2.4 analysis: https://github.com/rubocop/rubocop/pull/10632