### PR TITLE
Rename `RuboCop::AST::Token#regexp_dot?` to `RuboCop::AST::Token#regexp_dots`

### DIFF
--- a/changelog/change_rename_regexp_dot_to_regexp_dots.md
+++ b/changelog/change_rename_regexp_dot_to_regexp_dots.md
@@ -1,0 +1,1 @@
+* [#236](https://github.com/rubocop-hq/rubocop-ast/pull/236): **(Potentially Breaking)** Rename `RuboCop::AST::Token#regexp_dot?` to `RuboCop::AST::Token#regexp_dots`. ([@koic][])

--- a/lib/rubocop/ast/token.rb
+++ b/lib/rubocop/ast/token.rb
@@ -100,7 +100,7 @@ module RuboCop
         type == :tCOMMA
       end
 
-      def regexp_dot?
+      def regexp_dots?
         %i[tDOT2 tDOT3].include?(type)
       end
 

--- a/spec/rubocop/ast/token_spec.rb
+++ b/spec/rubocop/ast/token_spec.rb
@@ -236,15 +236,15 @@ RSpec.describe RuboCop::AST::Token do
       end
     end
 
-    describe '#regexp_dot?' do
+    describe '#regexp_dots?' do
       it 'returns true for regexp tokens' do
-        expect(irange_token).to be_regexp_dot
-        expect(erange_token).to be_regexp_dot
+        expect(irange_token).to be_regexp_dots
+        expect(erange_token).to be_regexp_dots
       end
 
       it 'returns false for non comma tokens' do
-        expect(semicolon_token).not_to be_regexp_dot
-        expect(right_ref_bracket_token).not_to be_regexp_dot
+        expect(semicolon_token).not_to be_regexp_dots
+        expect(right_ref_bracket_token).not_to be_regexp_dots
       end
     end
 


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-ast/pull/235#issuecomment-1179649807.

This PR renames `RuboCop::AST::Token#regexp_dot?` to `RuboCop::AST::Token#regexp_dots`.
It's been determined that it doesn't need to be an alias because it's the API that has just been released and isn't widespread.