### PR TITLE
Fix #macro? for numblock nodes

### DIFF
--- a/changelog/new_fix_macro_for_numblock_nodes.md
+++ b/changelog/new_fix_macro_for_numblock_nodes.md
@@ -1,0 +1,1 @@
+* [#237](https://github.com/rubocop/rubocop-ast/pull/237) Fix `#macro?` for numblock nodes ([@gsamokovarov][])

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -249,7 +249,7 @@ module RuboCop
           ^{                                       # or the parent is...
             sclass class module class_constructor? # a class-like node
             [ {                                    # or some "wrapper"
-                kwbegin begin block
+                kwbegin begin block numblock
                 (if _condition <%0 _>)  # note: we're excluding the condition of `if` nodes
               }
               #in_macro_scope?                     # that is itself in a macro scope

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -167,6 +167,33 @@ RSpec.describe RuboCop::AST::SendNode do
 
       it { expect(send_node).not_to be_bare_access_modifier }
     end
+
+    context 'with Ruby >= 2.7', :ruby27 do
+      context 'when node is access modifier in block' do
+        let(:source) do
+          <<~RUBY
+            included do
+            >> module_function <<
+            end
+          RUBY
+        end
+
+        it { expect(send_node).to be_bare_access_modifier }
+      end
+
+      context 'when node is access modifier in numblock' do
+        let(:source) do
+          <<~RUBY
+            included do
+            _1
+            >> module_function <<
+            end
+          RUBY
+        end
+
+        it { expect(send_node).to be_bare_access_modifier }
+      end
+    end
   end
 
   describe '#non_bare_access_modifier?' do
@@ -273,6 +300,19 @@ RSpec.describe RuboCop::AST::SendNode do
         end
 
         it { expect(send_node).to be_macro }
+      end
+
+      context 'with Ruby >= 2.7', :ruby27 do
+        context 'when parent is a numblock in a macro scope' do
+          let(:source) do
+            ['concern :Auth do',
+             '>>bar :baz<<',
+             '  bar _1',
+             'end'].join("\n")
+          end
+
+          it { expect(send_node).to be_macro }
+        end
       end
 
       context 'when parent is a block not in a macro scope' do


### PR DESCRIPTION
We can have macros in numblocks. I found this issue while working on broader `numblock` nodes support for cops in rubocop and found out that the`#bare_access_modifier?` method was not giving proper results for modifiers in numblocks. This applies to other methods that depend on the `#macro?` method.