### PR TITLE
Add `character_literal?` to `StrNode`

### DIFF
--- a/changelog/new_add_character_literal_to_str_node.md
+++ b/changelog/new_add_character_literal_to_str_node.md
@@ -1,0 +1,1 @@
+* [#242](https://github.com/rubocop/rubocop-ast/pull/242): Add `character_literal?` to `StrNode`. ([@koic][])

--- a/lib/rubocop/ast/node/str_node.rb
+++ b/lib/rubocop/ast/node/str_node.rb
@@ -8,6 +8,10 @@ module RuboCop
     class StrNode < Node
       include BasicLiteralNode
 
+      def character_literal?
+        loc.respond_to?(:begin) && loc.begin && loc.begin.is?('?')
+      end
+
       def heredoc?
         loc.is_a?(Parser::Source::Map::Heredoc)
       end

--- a/spec/rubocop/ast/str_node_spec.rb
+++ b/spec/rubocop/ast/str_node_spec.rb
@@ -30,6 +30,33 @@ RSpec.describe RuboCop::AST::StrNode do
     end
   end
 
+  describe '#character_literal?' do
+    context 'with a character literal' do
+      let(:source) { '?\n' }
+
+      it { is_expected.to be_character_literal }
+    end
+
+    context 'with a normal string literal' do
+      let(:source) { '"\n"' }
+
+      it { is_expected.not_to be_character_literal }
+    end
+
+    context 'with a heredoc' do
+      let(:source) do
+        <<~RUBY
+          <<-CODE
+            foo
+            bar
+          CODE
+        RUBY
+      end
+
+      it { is_expected.not_to be_character_literal }
+    end
+  end
+
   describe '#heredoc?' do
     context 'with a normal string' do
       let(:source) { "'foo'" }


### PR DESCRIPTION
This PR adds `character_literal?` to `StrNode`.

`...begin.is?('?')` used in https://github.com/rubocop/rubocop/pull/11095 and `Style/CharacterLiteral` can be rewritten by `node.character_literal?`.