### PR TITLE
Fix some offenses for `RSpec/ExampleWording`

### DIFF
--- a/spec/rubocop/ast/node_pattern/lexer_spec.rb
+++ b/spec/rubocop/ast/node_pattern/lexer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::AST::NodePattern::Lexer do
   context 'with $type+' do
     let(:source) { '(array sym $int+ x)' }
 
-    it 'works' do
+    it 'is parsed as `$ int + x`' do
       expect(tokens.map(&:last).map(&:first)).to eq \
         %i[( array sym $ int + x )]
     end
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::AST::NodePattern::Lexer do
   context 'when given arithmetic symbols' do
     let(:source) { ':&' }
 
-    it 'works' do
+    it 'is parsed as `:&`' do
       expect(tokens.map(&:last).map(&:first)).to eq [:&]
     end
   end


### PR DESCRIPTION
This PR is fixed several offenses of `RSpec/ExampleWording`.

```ruby
❯ bundle exec rubocop
Inspecting 162 files
.............................................................................................................................C....................................

Offenses:

spec/rubocop/ast/node_pattern/lexer_spec.rb:34:9: C: RSpec/ExampleWording: Your example description is insufficient.
    it 'works' do
        ^^^^^
spec/rubocop/ast/node_pattern/lexer_spec.rb:80:9: C: RSpec/ExampleWording: Your example description is insufficient.
    it 'works' do
        ^^^^^

162 files inspected, 2 offenses detected
```