### PR TITLE
Add node types `forwarded_restarg` and `forwarded_kwrestarg`

### DIFF
--- a/changelog/new_add_node_types_forwarded_restarg_and_forwarded_kwrestarg.md
+++ b/changelog/new_add_node_types_forwarded_restarg_and_forwarded_kwrestarg.md
@@ -1,0 +1,1 @@
+* [#245](https://github.com/rubocop/rubocop-ast/pull/245): Add node types `forwarded_restarg` and `forwarded_kwrestarg`. ([@ydah][])

--- a/docs/modules/ROOT/pages/node_types.adoc
+++ b/docs/modules/ROOT/pages/node_types.adoc
@@ -120,6 +120,10 @@ The following fields are given when relevant to nodes in the source code:
 
 |forwarded-args|Forwarding arguments into a method call|None|foo(...)|N/A
 
+|forwarded-restarg|Forwarding positional arguments into a method call|None|foo(*)|N/A
+
+|forwarded-kwrestarg|Forwarding keyword arguments into a method call|None|foo(**)|N/A
+
 |gvar|Global variable access|One child, the variable name as a symbol `:$foo`|$foo|N/A
 
 |gvasgn|Global variable assignment|Two children, the variable name `:$foo` and the expression being assigned|$foo = 5|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/AsgnNode[AsgnNode]

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -75,7 +75,8 @@ module RuboCop
       ### arity == 0
       no_children = %i[true false nil self cbase zsuper redo retry
                        forward_args forwarded_args match_nil_pattern
-                       forward_arg lambda empty_else kwnilarg
+                       forward_arg forwarded_restarg forwarded_kwrestarg
+                       lambda empty_else kwnilarg
                        __FILE__ __LINE__ __ENCODING__]
 
       ### arity == 0..1


### PR DESCRIPTION
This PR is added the node types added by https://github.com/whitequark/parser/pull/874

Now CI seems to be failing as well: 
https://github.com/rubocop/rubocop-ast/actions/runs/3581987367/jobs/6025686164#step:9:33