### PR TITLE
Optimize `Node#parent_module_name`

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -313,6 +313,8 @@ module RuboCop
       ## Searching the AST
 
       def parent_module_name
+        return 'Object' unless parent
+
         # what class or module is this method/constant/etc definition in?
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)


### PR DESCRIPTION
Related - https://github.com/rubocop/rubocop/pull/11240

There is no need to do all the complex traversing if there is no parent. 