### PR TITLE
Fix visitor pattern link formatting

### DIFF
--- a/docs/modules/ROOT/pages/node_pattern_compiler.adoc
+++ b/docs/modules/ROOT/pages/node_pattern_compiler.adoc
@@ -126,7 +126,7 @@ The compilation itself is handled by three subcompilers:
 
 === Visitors
 
-The subcompilers use the visitor pattern [https://en.wikipedia.org/wiki/Visitor_pattern]
+The subcompilers use the https://en.wikipedia.org/wiki/Visitor_pattern[visitor pattern].
 
 The methods starting with `visit_` are used to process the different types of nodes.
 For a node of type `:capture`, the method `visit_capture` will be called, or if none is defined then `visit_other_type` will be called.


### PR DESCRIPTION
This fixes the formatting of the "visitor pattern" link:

<table><tr><th>Before</th><th>After</th></tr>
<tr><td><blockquote>...the visitor pattern [https://en.wikipedia.org/wiki/Visitor_pattern]</blockquote></td><td><blockquote>...the <a href="https://en.wikipedia.org/wiki/Visitor_pattern">visitor pattern</a></blockquote></td></tr></table>

[This page on ASCII Doc](https://docs.asciidoctor.org/asciidoc/latest/macros/url-macro/#link-text) explains how to format links correctly.