### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.6, 2.7, "3.0", 3.1, head]
+        ruby: [2.6, 2.7, "3.0", 3.1, 3.2, head]
         coverage: [null]
         modern: [null]
         title: [null]


### PR DESCRIPTION
This PR is add Ruby 3.2 to the CI matrix
Because Ruby 3.2.0 is now in general release, it makes sense to add Ruby 3.2 to the CI matrix.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/