### PR TITLE
Improve the code example about `xstr`

### DIFF
--- a/docs/modules/ROOT/pages/node_types.adoc
+++ b/docs/modules/ROOT/pages/node_types.adoc
@@ -229,7 +229,7 @@ a|`foo` or `foo.bar`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST
 
 |while-post|Loop with condition coming last.|Two children. First child is an expression node for condition, second child is a body statement.|begin; foo; end while condition|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/WhileNode[WhileNode]
 
-|xstr|Execute string (backticks). The heredoc version is treated totally differently from the regular version.|Children are split into `str` nodes, with interpolation represented by separate expression nodes .|`foo#\{bar\}`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
+|xstr|Execute string (backticks). The heredoc version is treated totally differently from the regular version.|Children are split into `str` nodes, with interpolation represented by separate expression nodes .|\`date`|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/StrNode[StrNode]
 
 |yield|Yield to a block.|Children are expression nodes representing arguments.|yield(foo)|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/YieldNode[YieldNode]
 


### PR DESCRIPTION
This PR is improve the code example about `xstr`.

## Motivation

The code example for `xstr` appears to be incorrect from the [documentation](https://docs.rubocop.org/rubocop-ast/node_types.html).

![xstr](https://user-images.githubusercontent.com/13041216/216007519-85b013a3-9701-4bbe-b8ef-dabd9df13854.png)

The `foo#bar` looks more incorrect because it also looks like `dstr` and the backtick is not escaped.
Therefore, we would like to suggest using  \`date\` as a code example, as used in the following https://docs.ruby-lang.org/ document.

https://docs.ruby-lang.org/en/master/Kernel.html#method-i-60:~:text=%24-,%60date%60,-%23%20%3D%3E%20%22Wed%20Apr%20%209

![doc](https://user-images.githubusercontent.com/13041216/216009087-b15d2f5d-2a36-4a79-ba5e-a162e655f602.png)

After:
![after](https://user-images.githubusercontent.com/13041216/216008314-9af453f1-17e7-403a-a415-6d5b2c06f0fd.png)