### PR TITLE
Make `Node#class_constructor?` aware of `Data.define` and numbered parameters

### DIFF
--- a/changelog/new_make_class_constructor_aware_of_data_class.md
+++ b/changelog/new_make_class_constructor_aware_of_data_class.md
@@ -1,0 +1,1 @@
+* [#255](https://github.com/rubocop/rubocop-ast/pull/255): Make `Node#class_constructor?` aware of Ruby 3.2's `Data.define`. ([@koic][])

--- a/changelog/new_make_class_constructor_aware_of_numbered_parameters.md
+++ b/changelog/new_make_class_constructor_aware_of_numbered_parameters.md
@@ -1,0 +1,1 @@
+* [#255](https://github.com/rubocop/rubocop-ast/pull/255): Make `Node#class_construcor?` aware of Ruby 2.7's numbered parameters. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -513,7 +513,7 @@ module RuboCop
         {
           (send #global_const?({:Class :Module :Struct}) :new ...)
           (send #global_const?(:Data) :define ...)
-          (block {
+          ({block numblock} {
             (send #global_const?({:Class :Module :Struct}) :new ...)
             (send #global_const?(:Data) :define ...)
           } ...)

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -510,8 +510,14 @@ module RuboCop
 
       # @!method class_constructor?(node = self)
       def_node_matcher :class_constructor?, <<~PATTERN
-        {       (send #global_const?({:Class :Module :Struct}) :new ...)
-         (block (send #global_const?({:Class :Module :Struct}) :new ...) ...)}
+        {
+          (send #global_const?({:Class :Module :Struct}) :new ...)
+          (send #global_const?(:Data) :define ...)
+          (block {
+            (send #global_const?({:Class :Module :Struct}) :new ...)
+            (send #global_const?(:Data) :define ...)
+          } ...)
+        }
       PATTERN
 
       # @deprecated Use `:class_constructor?`

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -423,6 +423,32 @@ RSpec.describe RuboCop::AST::Node do
         expect(node).to be_class_constructor
       end
     end
+
+    context 'using Ruby >= 3.2', :ruby32 do
+      context 'Data definition with a block' do
+        let(:src) { 'Data.define(:foo, :bar) { def a = 42 }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'Data definition without block' do
+        let(:src) { 'Data.define(:foo, :bar)' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context '::Data' do
+        let(:src) { '::Data.define(:foo, :bar) { def a = 42 }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+    end
   end
 
   describe '#struct_constructor?' do

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -424,9 +424,43 @@ RSpec.describe RuboCop::AST::Node do
       end
     end
 
+    context 'using Ruby >= 2.7', :ruby27 do
+      context 'class definition with a numblock' do
+        let(:src) { 'Class.new { do_something(_1) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'module definition with a numblock' do
+        let(:src) { 'Module.new { do_something(_1) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'Struct definition with a numblock' do
+        let(:src) { 'Struct.new(:foo, :bar) { do_something(_1) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+    end
+
     context 'using Ruby >= 3.2', :ruby32 do
       context 'Data definition with a block' do
         let(:src) { 'Data.define(:foo, :bar) { def a = 42 }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'Data definition with a numblock' do
+        let(:src) { 'Data.define(:foo, :bar) { do_something(_1) }' }
 
         it 'matches' do
           expect(node).to be_class_constructor


### PR DESCRIPTION
This PR contains the following two commits:

## Make `Node#class_construcor?` aware of Ruby 3.2's `Data.define`

Ruby 3.2 introduced immutable `Data.define`. Since this is similar to `Struct.new`, `Node#class_constructor` will handle it in the same way.

## Make `Node#class_constructor?` aware of Ruby 2.7's numbered parameters

`Class.new`, `Module.new`, `Struct.new`, and `Data.define` take themselves as a block parameter.
These are the same when using numbered block parameter.

I will try to update https://github.com/rubocop/rubocop/pull/11546 and https://github.com/rubocop/rubocop/pull/11547 with this feature.