### PR TITLE
Support `Parser::Ruby33`

### DIFF
--- a/changelog/new_support_ruby_3_3_parser.md
+++ b/changelog/new_support_ruby_3_3_parser.md
@@ -1,0 +1,1 @@
+* [#256](https://github.com/rubocop-hq/rubocop-ast/pull/256): Support `Parser::Ruby33` for Ruby 3.3 parser (experimental). ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -265,6 +265,9 @@ module RuboCop
         when 3.2
           require 'parser/ruby32'
           Parser::Ruby32
+        when 3.3
+          require 'parser/ruby33'
+          Parser::Ruby33
         else
           raise ArgumentError,
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('parser', '>= 3.1.1.0')
+  s.add_runtime_dependency('parser', '>= 3.2.1.0')
 
   s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,10 @@ RSpec.shared_context 'ruby 3.2', :ruby32 do
   let(:ruby_version) { 3.2 }
 end
 
+RSpec.shared_context 'ruby 3.3', :ruby33 do
+  let(:ruby_version) { 3.3 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
Parser gem has been started development for Ruby 3.3 (edge Ruby).
https://github.com/whitequark/parser/pull/904

And this PR update to require Parser 3.2.1.0 or higher, which contains `Parser::Ruby33`. https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v3210-2023-02-09