### PR TITLE
Add `source_range` method to `NodePattern`

### DIFF
--- a/changelog/new_add_source_range_to_node_pattern.md
+++ b/changelog/new_add_source_range_to_node_pattern.md
@@ -1,0 +1,1 @@
+* [#229](https://github.com/rubocop/rubocop-ast/pull/229): Add `source_range` method to `NodePattern`. ([@koic][])

--- a/lib/rubocop/ast/ext/range.rb
+++ b/lib/rubocop/ast/ext/range.rb
@@ -15,8 +15,8 @@ module RuboCop
         #     :bar
         #   ]
         #
-        #   node.loc.begin.line_span                         # => 1..1
-        #   node.loc.expression.line_span(exclude_end: true) # => 1...4
+        #   node.loc.begin.line_span                       # => 1..1
+        #   node.source_range.line_span(exclude_end: true) # => 1...4
         def line_span(exclude_end: false)
           ::Range.new(first_line, last_line, exclude_end)
         end

--- a/lib/rubocop/ast/node_pattern/compiler/debug.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/debug.rb
@@ -47,7 +47,7 @@ module RuboCop
               # @return [String] a Rainbow colorized version of ruby
               def colorize(color_scheme = COLOR_SCHEME)
                 map = color_map(color_scheme)
-                ast.loc.expression.source_buffer.source.chars.map.with_index do |char, i|
+                ast.source_range.source_buffer.source.chars.map.with_index do |char, i|
                   Rainbow(char).color(map[i])
                 end.join
               end

--- a/lib/rubocop/ast/node_pattern/node.rb
+++ b/lib/rubocop/ast/node_pattern/node.rb
@@ -75,6 +75,10 @@ module RuboCop
           self.class.new(type, children, { location: location })
         end
 
+        def source_range
+          loc.expression
+        end
+
         INT_TO_RANGE = Hash.new { |h, k| h[k] = k..k }
         private_constant :INT_TO_RANGE
 

--- a/lib/rubocop/ast/node_pattern/with_meta.rb
+++ b/lib/rubocop/ast/node_pattern/with_meta.rb
@@ -48,12 +48,12 @@ module RuboCop
 
             def emit_unary_op(type, operator_t = nil, *children)
               children[-1] = children[-1].first if children[-1].is_a?(Array) # token?
-              map = source_map(children.first.loc.expression, operator_t: operator_t)
+              map = source_map(children.first.source_range, operator_t: operator_t)
               n(type, children, map)
             end
 
             def emit_list(type, begin_t, children, end_t)
-              expr = children.first.loc.expression.join(children.last.loc.expression)
+              expr = children.first.source_range.join(children.last.source_range)
               map = source_map(expr, begin_t: begin_t, end_t: end_t)
               n(type, children, map)
             end
@@ -79,8 +79,7 @@ module RuboCop
             end
 
             def join_exprs(left_expr, right_expr)
-              left_expr.loc.expression
-                       .join(right_expr.loc.expression)
+              left_expr.source_range.join(right_expr.source_range)
             end
 
             def source_map(token_or_range, begin_t: nil, end_t: nil, operator_t: nil, selector_t: nil)

--- a/spec/rubocop/ast/ext/range_spec.rb
+++ b/spec/rubocop/ast/ext/range_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::AST::Ext::Range do
     end
 
     it 'accepts an `exclude_end` keyword argument' do
-      expect(node.loc.expression.line_span(exclude_end: true)).to eq 1...4
+      expect(node.source_range.line_span(exclude_end: true)).to eq 1...4
     end
   end
 end

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       let(:hash) { array.children[1] }
 
       context 'provided source_range on line without comment' do
-        let(:range) { hash.pairs.first.loc.expression }
+        let(:range) { hash.pairs.first.source_range }
 
         it { is_expected.to be false }
       end
@@ -309,13 +309,13 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
 
       context 'provided source_range on line with comment' do
-        let(:range) { hash.pairs.last.loc.expression }
+        let(:range) { hash.pairs.last.source_range }
 
         it { is_expected.to be true }
       end
 
       context 'provided a multiline source_range with at least one line with comment' do
-        let(:range) { array.loc.expression }
+        let(:range) { array.source_range }
 
         it { is_expected.to be true }
       end


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/11630.

This PR provides a shorthand for `source_range` to `NodePattern`, like `RuboCop::AST::Node#source_range`. It will make a consistent rewrite of `loc.expression` to `source_range`. And resolves the following errors.

```console
% bundle exec rake
(snip)

Failures:

  1) RuboCop::AST::NodePattern::Parser sequences parses simple sequences properly
     Failure/Error: expr = children.first.source_range.join(children.last.source_range)

  NoMethodError: (-) undefined method `source_range' for s(:node_type, :int):RuboCop::AST::NodePattern::Node
  # ./lib/rubocop/ast/node_pattern/with_meta.rb:56:in `emit_list'
  # ./lib/rubocop/ast/node_pattern/parser.racc.rb:306:in `_reduce_3'
  # (eval):3:in `_racc_do_parse_c'
  # (eval):3:in `do_parse'
  # ./lib/rubocop/ast/node_pattern/with_meta.rb:102:in `do_parse'
  # ./lib/rubocop/ast/node_pattern/parser.rb:33:in `parse'
  # ./spec/rubocop/ast/node_pattern/parse_helper.rb:94:in `try_parsing'
  # ./spec/rubocop/ast/node_pattern/helper.rb:20:in `expect_parsing'
  # ./spec/rubocop/ast/node_pattern/parser_spec.rb:10:in `block (3 levels) in <top (required)>'
```