### PR TITLE
Fix an error when parsing non UTF-8 frozen string

### DIFF
--- a/changelog/fix_an_error_when_parsing_non_utf_8_frozen_string.md
+++ b/changelog/fix_an_error_when_parsing_non_utf_8_frozen_string.md
@@ -1,0 +1,1 @@
+* [#262](https://github.com/rubocop/rubocop-ast/pull/262): Fix an error when parsing non UTF-8 frozen string. ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -27,7 +27,7 @@ module RuboCop
         # Defaults source encoding to UTF-8, regardless of the encoding it has
         # been read with, which could be non-utf8 depending on the default
         # external encoding.
-        source.force_encoding(Encoding::UTF_8) unless source.encoding == Encoding::UTF_8
+        (+source).force_encoding(Encoding::UTF_8) unless source.encoding == Encoding::UTF_8
 
         @raw_source = source
         @path = path

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     let(:source) { "# \xf9" }
   end
 
+  describe '#initialize' do
+    context 'when parsing non UTF-8 frozen string' do
+      let(:source) { (+'true').force_encoding(Encoding::ASCII_8BIT).freeze }
+
+      it 'returns an instance of ProcessedSource' do
+        is_expected.to be_a(described_class)
+      end
+    end
+  end
+
   describe '.from_file' do
     describe 'when the file exists' do
       around do |example|


### PR DESCRIPTION
This PR fixes the following `FrozenError` when parsing non UTF-8 frozen string:

```console
$ cat example.rb
# encoding: ascii-8bit
# frozen_string_literal: true

require 'rubocop-ast'

RuboCop::AST::ProcessedSource.new('true', 3.2)
```

```console
$ ruby example.rb
/Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rubocop-ast-1.28.0/lib/rubocop/ast/processed_source.rb:30:
in `force_encoding': can't modify frozen String: "true" (FrozenError)
from /Users/koic/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/rubocop-ast-1.28.0/lib/rubocop/ast/processed_source.rb:30:
in `initialize'
from example.rb:6:in `new'
from example.rb:6:in `<main>'
```