### PR TITLE
Fix a build error when using Ruby 2.6 runtime

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.6, 2.7]
+        ruby: [2.7]
         rubocop: [master]
         internal_investigation: [null]
         include:


### PR DESCRIPTION
The master brach of RuboCop has been dropped Ruby 2.6 runtime support. https://github.com/rubocop/rubocop/pull/11791

This PR fixes the following build error:

```
Run cd ../rubocop && bundle install --jobs 3 --retry 3
Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler.
Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version.
Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Could not find compatible versions

Because every version of rubocop depends on Ruby >= 2.7.0
and Gemfile depends on rubocop >= 0,
Ruby >= 2.7.0 is required.
So, because current Ruby version is = 2.6.10,
version solving has failed.
```

https://github.com/rubocop/rubocop-ast/actions/runs/4857086508/jobs/8657259864