### PR TITLE
Fix new cop offense (for green ci)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'bump', require: false
+gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'oedipus_lex', '>= 2.6.0', require: false
 gem 'racc'
 gem 'rake', '~> 13.0'

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -35,7 +35,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('parser', '>= 3.2.1.0')
 
-  s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
-
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end


### PR DESCRIPTION
see https://github.com/rubocop/rubocop-ast/actions/runs/5039437879/jobs/9037577956

````
 rubocop-ast.gemspec:38:3: C: Gemspec/DevelopmentDependencies: Specify development dependencies in Gemfile.
  s.add_development_dependency('bundler', '>= 1.15.0', '< 3.0')
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```