### PR TITLE
Introduce RuboCop::Ast::MethodDispatchNode#selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#262](https://github.com/rubocop/rubocop-ast/pull/267): Introduce RuboCop::Ast::MethodDispatchNode#selector. ([@gsamokovarov][])
+
 ## 1.28.1 (2023-05-01)
 
 ### Bug fixes

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -5,7 +5,7 @@ module RuboCop
     # Common functionality for nodes that are a kind of method dispatch:
     # `send`, `csend`, `super`, `zsuper`, `yield`, `defined?`,
     # and (modern only): `index`, `indexasgn`, `lambda`
-    module MethodDispatchNode
+    module MethodDispatchNode # rubocop:disable Metrics/ModuleLength
       extend NodePattern::Macros
       include MethodIdentifierPredicates
 
@@ -26,6 +26,17 @@ module RuboCop
       # @return [Symbol] the name of the dispatched method
       def method_name
         node_parts[1]
+      end
+
+      # The source range for the method name or keyword that dispatches this call.
+      #
+      # @return [Parser::Source::Range] the source range for the method name or keyword
+      def selector
+        if loc.respond_to? :keyword
+          loc.keyword
+        else
+          loc.selector
+        end
       end
 
       # The `block` or `numblock` node associated with this method dispatch, if any.
@@ -147,7 +158,7 @@ module RuboCop
       #
       # @return [Boolean] whether the method is the implicit form of `#call`
       def implicit_call?
-        method?(:call) && !loc.selector
+        method?(:call) && !selector
       end
 
       # Whether this method dispatch has an explicit block.
@@ -222,9 +233,9 @@ module RuboCop
       #
       # @return [Boolean] whether this method is a unary operation
       def unary_operation?
-        return false unless loc.selector
+        return false unless selector
 
-        operator_method? && loc.expression.begin_pos == loc.selector.begin_pos
+        operator_method? && loc.expression.begin_pos == selector.begin_pos
       end
 
       # Checks whether this is a binary operation.
@@ -235,9 +246,9 @@ module RuboCop
       #
       # @return [Boolean] whether this method is a binary operation
       def binary_operation?
-        return false unless loc.selector
+        return false unless selector
 
-        operator_method? && loc.expression.begin_pos != loc.selector.begin_pos
+        operator_method? && loc.expression.begin_pos != selector.begin_pos
       end
 
       private

--- a/spec/rubocop/ast/super_node_spec.rb
+++ b/spec/rubocop/ast/super_node_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe RuboCop::AST::SuperNode do
     it { expect(super_node.method_name).to eq(:super) }
   end
 
+  describe '#selector' do
+    let(:source) { 'super(foo)' }
+
+    it { expect(super_node.selector.source).to eq('super') }
+  end
+
   describe '#method?' do
     context 'when message matches' do
       context 'when argument is a symbol' do

--- a/spec/rubocop/ast/yield_node_spec.rb
+++ b/spec/rubocop/ast/yield_node_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe RuboCop::AST::YieldNode do
     it { expect(yield_node.method_name).to eq(:yield) }
   end
 
+  describe '#selector' do
+    let(:source) { 'yield :foo, :bar' }
+
+    it { expect(yield_node.selector.source).to eq('yield') }
+  end
+
   describe '#method?' do
     context 'when message matches' do
       context 'when argument is a symbol' do


### PR DESCRIPTION
If you need to manipulate the call-site of a method dispatch, you have to use `node.loc.selector` for regular methods and `node.loc.keyword` for syntax nodes that behave like method invocations. Super and yield nodes are nodes are examples.

This forces us to check if `node.loc` responds to `#keyword` in a few places in rubocop proper and we can make it easier if we expose a single method called `#selector` (the name is up for debate) and use it for method dispatch nodes.

As an example, see [HashSyntaxShorthand](https://github.com/rubocop/rubocop/blob/7259df96e689f80828eb231495cc515011585bd9/lib/rubocop/cop/mixin/hash_shorthand_syntax.rb#L206-L224) where I had to define a struct to hide away the selector detection.