### PR TITLE
Fix "Chacks" -> "Checks" typo

### DIFF
--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -81,7 +81,7 @@ module RuboCop
         (if? || unless?) && super
       end
 
-      # Chacks whether the `if` node has nested `if` nodes in any of its
+      # Checks whether the `if` node has nested `if` nodes in any of its
       # branches.
       #
       # @note This performs a shallow search.


### PR DESCRIPTION
This just fixes a typo in a comment. For some reason it caused failing CI on #270.