### PR TITLE
Support `Parser::Ruby34`

### DIFF
--- a/changelog/new_support_ruby_3_4_parser.md
+++ b/changelog/new_support_ruby_3_4_parser.md
@@ -1,0 +1,1 @@
+* [#276](https://github.com/rubocop-hq/rubocop-ast/pull/276): Support `Parser::Ruby34` for Ruby 3.4 parser (experimental). ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -268,6 +268,9 @@ module RuboCop
         when 3.3
           require 'parser/ruby33'
           Parser::Ruby33
+        when 3.4
+          require 'parser/ruby34'
+          Parser::Ruby34
         else
           raise ArgumentError,
                 "RuboCop found unknown Ruby version: #{ruby_version.inspect}"

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('parser', '>= 3.2.1.0')
+  s.add_runtime_dependency('parser', '>= 3.3.0.4')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,10 @@ RSpec.shared_context 'ruby 3.3', :ruby33 do
   let(:ruby_version) { 3.3 }
 end
 
+RSpec.shared_context 'ruby 3.4', :ruby34 do
+  let(:ruby_version) { 3.4 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
Parser gem has been started development for Ruby 3.4 (edge Ruby).
https://github.com/whitequark/parser/pull/991

And this PR update to require Parser 3.3.0.4 or higher, which contains `Parser::Ruby34`. https://github.com/whitequark/parser/blob/master/CHANGELOG.md#not-released-2024-01-15