### PR TITLE
Support Prism as a Ruby parser

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -76,6 +76,23 @@ jobs:
       - name: spec
         if: "matrix.coverage != true && matrix.internal_investigation != true"
         run: bundle exec rake spec
+  prism:
+    runs-on: ubuntu-latest
+    name: Prism
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Specify the minimum Ruby version 2.7 required for Prism to run.
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: spec
+        env:
+          # Specify the minimum Ruby version 3.3 required for Prism to analyze.
+          PARSER_ENGINE: parser_prism
+          TARGET_RUBY_VERSION: 3.3
+        run: bundle exec rake prism_spec
   rubocop_specs:
     name: >-
       Main Gem Specs | RuboCop: ${{ matrix.rubocop }} | ${{ matrix.ruby }}

--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,23 @@ RSpec::Core::RakeTask.new(spec: :generate) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
+desc 'Run RSpec code examples with Prism'
+task prism_spec: :generate do
+  original_parser_engine = ENV.fetch('PARSER_ENGINE', nil)
+  original_target_ruby_version = ENV.fetch('TARGET_RUBY_VERSION', nil)
+
+  RSpec::Core::RakeTask.new(prism_spec: :generate) do |spec|
+    # Specify the minimum Ruby version 3.3 required for Prism to analyze.
+    ENV['PARSER_ENGINE'] = 'parser_prism'
+    ENV['TARGET_RUBY_VERSION'] = '3.3'
+
+    spec.pattern = FileList['spec/**/*_spec.rb']
+  end
+
+  ENV['PARSER_ENGINE'] = original_parser_engine
+  ENV['TARGET_RUBY_VERSION'] = original_target_ruby_version
+end
+
 desc 'Run RSpec with code coverage'
 task :coverage do
   ENV['COVERAGE'] = 'true'
@@ -35,5 +52,6 @@ end
 
 task default: %i[
   spec
+  prism_spec
   internal_investigation
 ]

--- a/changelog/new_support_prism.md
+++ b/changelog/new_support_prism.md
@@ -1,0 +1,1 @@
+* [#277](https://github.com/rubocop/rubocop-ast/pull/277): Support Prism as a Ruby parser (experimental). ([@koic][])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -82,3 +82,14 @@ source = RuboCop::AST::ProcessedSource.new(code, 2.7)
 rule = MyRule.new
 source.ast.each_node { |n| rule.process(n) }
 ----
+
+In RuboCop AST, you can specify Prism as the parser engine backend by setting `parser_engine: :parser_prism`:
+
+```ruby
+# Using the Parser gem with `parser_engine: parser_whitequark` is the default.
+ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism)
+```
+
+This is an experimental feature. If you encounter any incompatibilities between
+Prism and the Parser gem, please check the following URL:
+https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('parser', '>= 3.3.0.4')
+  s.add_runtime_dependency('prism', '>= 0.24.0')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::AST::IfNode do
+# FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
+RSpec.describe RuboCop::AST::IfNode, broken_on: :prism do
   subject(:if_node) { parse_source(source).ast }
 
   describe '.new' do

--- a/spec/rubocop/ast/range_node_spec.rb
+++ b/spec/rubocop/ast/range_node_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe RuboCop::AST::RangeNode do
       it { is_expected.to be_range_type }
     end
 
-    context 'with an infinite range' do
-      let(:ruby_version) { 2.6 }
+    context 'with an infinite range', :ruby26 do
       let(:source) do
         '1..'
       end
@@ -32,8 +31,7 @@ RSpec.describe RuboCop::AST::RangeNode do
       it { is_expected.to be_range_type }
     end
 
-    context 'with a beignless range' do
-      let(:ruby_version) { 2.7 }
+    context 'with a beignless range', :ruby27 do
       let(:source) do
         '..42'
       end

--- a/spec/rubocop/ast/token_spec.rb
+++ b/spec/rubocop/ast/token_spec.rb
@@ -342,7 +342,9 @@ RSpec.describe RuboCop::AST::Token do
       end
 
       describe '#left_brace?' do
-        it 'returns true for left hash brace tokens' do
+        # FIXME: `broken_on: :prism` can be removed when
+        # https://github.com/ruby/prism/issues/2454 will be released.
+        it 'returns true for left hash brace tokens', broken_on: :prism do
           expect(left_hash_brace_token).to be_left_brace
         end
 
@@ -357,7 +359,9 @@ RSpec.describe RuboCop::AST::Token do
           expect(left_block_brace_token).to be_left_curly_brace
         end
 
-        it 'returns false for non left block brace tokens' do
+        # FIXME: `broken_on: :prism` can be removed when
+        # https://github.com/ruby/prism/issues/2454 will be released.
+        it 'returns false for non left block brace tokens', broken_on: :prism do
           expect(left_hash_brace_token).not_to be_left_curly_brace
           expect(right_block_brace_token).not_to be_left_curly_brace
         end

--- a/spec/rubocop/ast/traversal_spec.rb
+++ b/spec/rubocop/ast/traversal_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe RuboCop::AST::Traversal do
 
       let(:source) { "foo=bar=baz=nil; #{example}" }
 
-      it 'traverses all nodes' do
+      # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
+      it 'traverses all nodes', broken_on: :prism do
         actual = node.each_node.count
         expect(traverse.hits).to eql(actual)
       end

--- a/spec/rubocop/ast/until_node_spec.rb
+++ b/spec/rubocop/ast/until_node_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe RuboCop::AST::UntilNode do
     it { expect(until_node.inverse_keyword).to eq('while') }
   end
 
-  describe '#do?' do
+  # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
+  describe '#do?', broken_on: :prism do
     context 'with a do keyword' do
       let(:source) { 'until foo do; bar; end' }
 

--- a/spec/rubocop/ast/while_node_spec.rb
+++ b/spec/rubocop/ast/while_node_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe RuboCop::AST::WhileNode do
   end
 
   describe '#do?' do
-    context 'with a do keyword' do
+    # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
+    context 'with a do keyword', broken_on: :prism do
       let(:source) { 'while foo do; bar; end' }
 
       it { is_expected.to be_do }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,35 +20,43 @@ if ENV['MODERNIZE']
 end
 
 RSpec.shared_context 'ruby 2.3', :ruby23 do
-  let(:ruby_version) { 2.3 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.3 }
 end
 
 RSpec.shared_context 'ruby 2.4', :ruby24 do
-  let(:ruby_version) { 2.4 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
 RSpec.shared_context 'ruby 2.5', :ruby25 do
-  let(:ruby_version) { 2.5 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.5 }
 end
 
 RSpec.shared_context 'ruby 2.6', :ruby26 do
-  let(:ruby_version) { 2.6 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.6 }
 end
 
 RSpec.shared_context 'ruby 2.7', :ruby27 do
-  let(:ruby_version) { 2.7 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.7 }
 end
 
 RSpec.shared_context 'ruby 3.0', :ruby30 do
-  let(:ruby_version) { 3.0 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.0 }
 end
 
 RSpec.shared_context 'ruby 3.1', :ruby31 do
-  let(:ruby_version) { 3.1 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.1 }
 end
 
 RSpec.shared_context 'ruby 3.2', :ruby32 do
-  let(:ruby_version) { 3.2 }
+  # Prism supports parsing Ruby 3.3+.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 3.2 }
 end
 
 RSpec.shared_context 'ruby 3.3', :ruby33 do
@@ -63,7 +71,13 @@ end
 module DefaultRubyVersion
   extend RSpec::SharedContext
 
-  let(:ruby_version) { 2.4 }
+  let(:ruby_version) { ENV.fetch('TARGET_RUBY_VERSION', 2.4).to_f }
+end
+
+module DefaultParserEngine
+  extend RSpec::SharedContext
+
+  let(:parser_engine) { ENV.fetch('PARSER_ENGINE', :parser_whitequark).to_sym }
 end
 
 module RuboCop
@@ -80,7 +94,7 @@ module ParseSourceHelper
   def parse_source(source)
     lookup = nil
     ruby = source.gsub(/>>(.*)<</) { lookup = Regexp.last_match(1).strip }
-    source = RuboCop::AST::ProcessedSource.new(ruby, ruby_version, nil)
+    source = RuboCop::AST::ProcessedSource.new(ruby, ruby_version, nil, parser_engine: parser_engine)
     source.node = if lookup
                     source.ast.each_node.find(
                       -> { raise "No node corresponds to source '#{lookup}'" }
@@ -95,6 +109,7 @@ end
 RSpec.configure do |config|
   config.include ParseSourceHelper
   config.include DefaultRubyVersion
+  config.include DefaultParserEngine
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
   config.filter_run_when_matching :focus
@@ -111,6 +126,8 @@ RSpec.configure do |config|
     mocks.syntax = :expect
     mocks.verify_partial_doubles = true
   end
+
+  config.filter_run_excluding broken_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
 
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
This PR introduces the `parser_engine` option to `ProcessedSource` to support Prism, as part of the RuboCop AST side effort towards addressing https://github.com/rubocop/rubocop/issues/12600.

## Configuration

By default, analysis is performed using the Parser gem, so the default value for the newly added `parser_engine` is `parser_whitequark`:

```ruby
ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_whitequark)
```

This code maintains compatibility, meaning the traditional behavior is preserved:

```ruby
ProcessedSource.new(@options[:stdin], ruby_version, file)
```

To perform analysis using Prism, specify `parser_engine: :parser_prism`:

```ruby
ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism)
```

The parameter name `parser_prism` reflects the original parser_prism which was the basis for `Prism::Translation::Parser` (now integrated into Prism): https://github.com/kddnewton/parser-prism

This is an experimental introduction, and some incompatibilities still remain.

> [!NOTE]
> As initially mentioned in https://github.com/rubocop/rubocop/issues/12600#issuecomment-1933657732,
> the plan was to set `parser_engine: prism`.
>
> However, the parser engine used in this PR is `Prism::Translation::Parser`, not `Prism`:
> https://github.com/ruby/prism/pull/2419
>
> `Prism::Translation::Parser` and `Prism` have different ASTs, so their migration will definitely cause incompatibility.
> So, considering the possibility of further replacing `Prism::Translation::Parser` with `Prism` in the future,
> it has been decided that it might be better not to use `ParserEngine: prism` for the time being.
> `ParserEngine: prism` is reserved for `Prism`, not `Prism::Translation::Parser`.
>
> Therefore, the parameter value has been set to `parser_engine: parser_prism` specifically for
> `Prism::Translation::Parser`.
>
> This means that the planned way to specify Prism in .rubocop.yml file will be `ParserEngine: parser_prism`,
> not `ParserEngine: prism`.

## Compatibility

The compatibility issues between Prism and the Parser gem have not been resolved. The failing tests will be skipped with `broken_on: :prism`:

- https://github.com/ruby/prism/issues/2454 has been resolved but not yet released.
- https://github.com/ruby/prism/issues/2467 is still unresolved.

Issues that will be resolved in several upcoming releases of Prism are being skipped with `broken_on: :prism`.

Anyway, RuboCop AST can be released independently of the resolution and release of Prism.

> [!NOTE]
> The hack in `Prism::Translation::Parser` for `ProcessedSource` needs to be fixed:
> https://github.com/ruby/prism/blob/v0.24.0/lib/prism/translation/parser/rubocop.rb
>
> If the above interface is accepted, a fix will be proposed on the Prism side.

## Test

Tests for RuboCop AST with Prism as the backend can be run as follows:

```console
bundle exec rake prism_spec
```

The above is the shortcut alias for:

```console
PARSER_ENGINE=parser_prism TARGET_RUBY_VERSION=3.3 rake spec
```

RuboCop AST works on Ruby versions 2.6+, but since Prism only targets analysis for Ruby 3.3+, `internal_investigation` Rake task will not be executed. This task is only run with the Parser gem, which can analyze Ruby versions 2.0+.