### PR TITLE
Fix a build error

### DIFF
--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 RSpec.describe RuboCop::AST::Node do
   let(:ast) { parse_source(src).node }
   let(:node) { ast }


### PR DESCRIPTION
This PR fixes the following build error when using Ruby 3.4dev:

```console
$ ruby -v
ruby 3.4.0dev (2024-02-24T04:19:37Z master e9e752c7ef) [x86_64-darwin23]
$ bundle exec rspec ./spec/rubocop/ast/node_spec.rb:322
Run options: include {:locations=>{"./spec/rubocop/ast/node_spec.rb"=>[322]}}

Randomized with seed 21659
F

Failures:

  1) RuboCop::AST::Node#pure? for a regexp with no interpolation returns true
     Failure/Error: let(:src) { URI::DEFAULT_PARSER.make_regexp.inspect }

     NameError:
       uninitialized constant URI
     # ./spec/rubocop/ast/node_spec.rb:320:in 'block (5 levels) in <top (required)>'
     # ./spec/rubocop/ast/node_spec.rb:4:in 'block (2 levels) in <top (required)>'
     # ./spec/rubocop/ast/node_spec.rb:5:in 'block (2 levels) in <top (required)>'
     # ./spec/rubocop/ast/node_spec.rb:323:in 'block (5 levels) in <top (required)>'

Finished in 0.00259 seconds (files took 0.32884 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/rubocop/ast/node_spec.rb:322 # RuboCop::AST::Node#pure? for a regexp with no interpolation returns true
```