### PR TITLE
Drop Ruby 2.6 runtime support

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -29,13 +29,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.6, 2.7, "3.0", 3.1, 3.2, 3.3, head]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3, head]
         coverage: [null]
         modern: [null]
         title: [null]
         include:
           - { os: windows, ruby: mingw }
-          - { ruby: 2.6, os: ubuntu, coverage: true, title: "Coverage" }
+          - { ruby: 2.7, os: ubuntu, coverage: true, title: "Coverage" }
           - { ruby: "3.0", os: ubuntu, modern: true, title: 'Specs "modern"' }
           - { ruby: jruby, os: ubuntu }
           # jruby disabled because of: https://github.com/jruby/jruby/issues/6416

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - 'lib/rubocop/ast/node_pattern/lexer.rex.rb'
     - 'spec/rubocop/ast/node_pattern/parse_helper.rb'
     - 'spec/rubocop/ast/fixtures/*'
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   SuggestExtensions: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.

--- a/changelog/change_drop_ruby_26_runtime_support.md
+++ b/changelog/change_drop_ruby_26_runtime_support.md
@@ -1,0 +1,1 @@
+* [#279](https://github.com/rubocop/rubocop-ast/pull/279): **(Compatibility)** Drop Ruby 2.6 runtime support. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -326,13 +326,13 @@ module RuboCop
         # what class or module is this method/constant/etc definition in?
         # returns nil if answer cannot be determined
         ancestors = each_ancestor(:class, :module, :sclass, :casgn, :block)
-        result    = ancestors.map do |ancestor|
+        result    = ancestors.filter_map do |ancestor|
           parent_module_name_part(ancestor) do |full_name|
             return nil unless full_name
 
             full_name
           end
-        end.compact.reverse.join('::')
+        end.reverse.join('::')
         result.empty? ? 'Object' : result
       end
 

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop-ast'
   s.version = RuboCop::AST::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     RuboCop's Node and NodePattern classes.


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop-ast/pull/277#issuecomment-1962302045.

This PR drops Ruby 2.6 runtime support to prepare to support Prism.