### PR TITLE
Fix a build error

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -92,7 +92,7 @@ jobs:
         internal_investigation: [null]
         include:
           - { rubocop: master, ruby: "3.0", os: ubuntu }
-          - { rubocop: "v1.35.0", ruby: "3.3", os: ubuntu }
+          - { rubocop: "v1.57.2", ruby: "3.3", os: ubuntu }
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR resolves the following CI error with RuboCop 1.35.0:

```console
  1) RuboCop Project requiring all of `lib` with verbose warnings enabled emits no warnings
     Failure/Error: expect(warnings).to eq []

       expected: []
            got: ["/home/runner/work/rubocop-ast/rubocop/lib/rubocop/formatter/html_formatter.rb:6:
warning: base64 wa...l no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.\n"]

       (compared using ==)

       Diff:
       @@ -1 +1,2 @@
       +/home/runner/work/rubocop-ast/rubocop/lib/rubocop/formatter/html_formatter.rb:6: warning:
base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0.
Add base64 to your Gemfile or gemspec.\n

     # ./spec/project_spec.rb:284:in `block (3 levels) in <top (required)>'
```

https://github.com/rubocop/rubocop-ast/actions/runs/8033104014/job/21943241393

It updates RuboCop to 1.57.2, which was finally resolved by https://github.com/rubocop/rubocop/pull/12313.