### PR TITLE
Remove useless `TARGET_RUBY_VERSION` env var

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -89,9 +89,7 @@ jobs:
           bundler-cache: true
       - name: spec
         env:
-          # Specify the minimum Ruby version 3.3 required for Prism to analyze.
           PARSER_ENGINE: parser_prism
-          TARGET_RUBY_VERSION: 3.3
         run: bundle exec rake prism_spec
   rubocop_specs:
     name: >-

--- a/Rakefile
+++ b/Rakefile
@@ -25,18 +25,14 @@ end
 desc 'Run RSpec code examples with Prism'
 task prism_spec: :generate do
   original_parser_engine = ENV.fetch('PARSER_ENGINE', nil)
-  original_target_ruby_version = ENV.fetch('TARGET_RUBY_VERSION', nil)
 
   RSpec::Core::RakeTask.new(prism_spec: :generate) do |spec|
-    # Specify the minimum Ruby version 3.3 required for Prism to analyze.
     ENV['PARSER_ENGINE'] = 'parser_prism'
-    ENV['TARGET_RUBY_VERSION'] = '3.3'
 
     spec.pattern = FileList['spec/**/*_spec.rb']
   end
 
   ENV['PARSER_ENGINE'] = original_parser_engine
-  ENV['TARGET_RUBY_VERSION'] = original_target_ruby_version
 end
 
 desc 'Run RSpec with code coverage'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,8 @@ end
 module DefaultRubyVersion
   extend RSpec::SharedContext
 
-  let(:ruby_version) { ENV.fetch('TARGET_RUBY_VERSION', 2.4).to_f }
+  # The minimum version Prism can parse is 3.3.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
 module DefaultParserEngine


### PR DESCRIPTION
This PR removes useless `TARGET_RUBY_VERSION` env var and uses `PARSER_ENGINE` env var instead.

In fact, the `ruby_version` in `shared_context` is replaced with the value required by `PARSER_ENGINE`:
https://github.com/rubocop/rubocop-ast/blob/49b135be4a4edce97955a1e987d50a295f72a907/spec/spec_helper.rb#L22-L60