### PR TITLE
[Fix #282] Remove Prism from runtime dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gemspec
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'oedipus_lex', '>= 2.6.0', require: false
+gem 'prism', '>= 0.24.0'
 gem 'racc'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'

--- a/changelog/change_remove_parser_from_runtime_dependency.md
+++ b/changelog/change_remove_parser_from_runtime_dependency.md
@@ -1,0 +1,1 @@
+* [#282](https://github.com/rubocop/rubocop-ast/issues/282): Remove Prism from runtime dependency. ([@koic][])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -83,7 +83,15 @@ rule = MyRule.new
 source.ast.each_node { |n| rule.process(n) }
 ----
 
-In RuboCop AST, you can specify Prism as the parser engine backend by setting `parser_engine: :parser_prism`:
+In RuboCop AST, you can specify Prism as the parser engine backend.
+
+If running through Bundler, please first add `gem 'prism'` to your Gemfile:
+
+```ruby
+gem 'prism'
+```
+
+By specifying `parser_engine: :parser_prism`, parsing with Prism can be processed:
 
 ```ruby
 # Using the Parser gem with `parser_engine: parser_whitequark` is the default.

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -286,7 +286,12 @@ module RuboCop
             raise ArgumentError, "RuboCop found unknown Ruby version: #{ruby_version.inspect}"
           end
         when :parser_prism
-          require 'prism'
+          begin
+            require 'prism'
+          rescue LoadError
+            warn "Error: Unable to load Prism. Add `gem 'prism'` to your Gemfile."
+            exit!
+          end
 
           case ruby_version
           when 3.3

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   }
 
   s.add_runtime_dependency('parser', '>= 3.3.0.4')
-  s.add_runtime_dependency('prism', '>= 0.24.0')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end


### PR DESCRIPTION
Fixes #282.

This PR removes Prism from runtime dependency.

If it is decided that Prism will not be a runtime dependency for the time being, error message and documentation will be used to communicate the dependency on Prism to users.

Making it a default runtime dependency will be avoided until at least #282 installation error with Prism is resolved.