### PR TITLE
Improve error message for invalid `parser_engine` value

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -27,9 +27,10 @@ module RuboCop
       end
 
       def initialize(source, ruby_version, path = nil, parser_engine: :parser_whitequark)
+        parser_engine = parser_engine.to_sym
         unless PARSER_ENGINES.include?(parser_engine)
-          raise ArgumentError, 'The keyword argument `parser_engine` accepts ' \
-                               "`parser` or `parser_prism`, but `#{parser_engine}` was passed."
+          raise ArgumentError, 'The keyword argument `parser_engine` accepts `parser_whitequark` ' \
+                               "or `parser_prism`, but `#{parser_engine}` was passed."
         end
 
         # Defaults source encoding to UTF-8, regardless of the encoding it has

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -28,15 +28,26 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
-    context 'when using invalid `parser_engine` argument' do
-      let(:parser_engine) { :unknown_parser_engine }
-
-      it 'raises a Errno::ENOENT when the file does not exist' do
+    shared_examples 'invalid parser_engine' do
+      it 'raises ArgumentError' do
         expect { processed_source }.to raise_error(ArgumentError) do |e|
-          expect(e.message).to eq 'The keyword argument `parser_engine` accepts `parser` or ' \
-                                  '`parser_prism`, but `unknown_parser_engine` was passed.'
+          expected =  'The keyword argument `parser_engine` accepts `parser_whitequark` ' \
+                      "or `parser_prism`, but `#{parser_engine}` was passed."
+          expect(e.message).to eq(expected)
         end
       end
+    end
+
+    context 'when using an invalid `parser_engine` symbol argument' do
+      let(:parser_engine) { :unknown_parser_engine }
+
+      it_behaves_like 'invalid parser_engine'
+    end
+
+    context 'when using an invalid `parser_engine` string argument' do
+      let(:parser_engine) { 'unknown_parser_engine' }
+
+      it_behaves_like 'invalid parser_engine'
     end
   end
 


### PR DESCRIPTION
`parser` doesn't exist, it must be `parser_whitequark`. In addition, this only accepts symbols.

When passing a string, this would previously print ``The keyword argument `parser_engine` accepts `parser` or `parser_prism`, but `parser_prism` was passed.``. Use `inspect` to clearly show what you did wrong.

The new error message looks like this: ``The keyword argument `parser_engine` accepts `:parser_whitequark` or `:parser_prism`, but `"parser_prism"` was passed.``.