### PR TITLE
Fix a ruby warning when executing with `bundle exec rubocop` in this repository

### DIFF
--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.email = 'rubocop@googlegroups.com'
   s.files = `git ls-files lib LICENSE.txt README.md`
-            .split($RS) + %w[
+            .lines(chomp: true) + %w[
               lib/rubocop/ast/node_pattern/parser.racc.rb
               lib/rubocop/ast/node_pattern/lexer.rex.rb
             ]


### PR DESCRIPTION
`check_commit.rake` requires 'English' but when doing `bundle exec rubocop` this repository this file will also be evaluated.

This also happens in the `rubocop` repository (my main motivation here) if `rubocop-ast` is in the parent folder because of this line in its Gemfile: https://github.com/rubocop/rubocop/blob/66c8276b5d9e60fed1fb8d937649c3c153e5037d/Gemfile#L29-L30

```
$ RUBYOPT=-w bundle exec rubocop -V
.../rubocop-ast/rubocop-ast.gemspec:18: warning: global variable `$RS' not initialized
1.62.1 (using Parser 3.3.0.5, rubocop-ast 1.31.2, running on ruby 3.3.0) [x86_64-linux]
  - rubocop-performance 1.20.2
  - rubocop-rspec 2.27.1
```