### PR TITLE
Handle encoding error from the parser gem

### DIFF
--- a/changelog/fix_error_for_magic_encoding_comment.md
+++ b/changelog/fix_error_for_magic_encoding_comment.md
@@ -1,0 +1,1 @@
+* [#289](https://github.com/rubocop/rubocop-ast/pull/289): Fix an error during parsing when encountering unknown encodings in the encoding magic comment. ([@Earlopain][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -209,7 +209,7 @@ module RuboCop
 
         begin
           @buffer.source = source
-        rescue EncodingError => e
+        rescue EncodingError, Parser::UnknownEncodingInMagicComment => e
           @parser_error = e
           @ast = nil
           @comments = []

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_runtime_dependency('parser', '>= 3.3.0.4')
+  s.add_runtime_dependency('parser', '>= 3.3.1.0')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
+    context 'when parsing code with an invalid encoding comment' do
+      let(:source) { '# encoding: foobar' }
+
+      it 'returns a parser error' do
+        expect(processed_source.parser_error).to be_a(Parser::UnknownEncodingInMagicComment)
+        expect(processed_source.parser_error.message)
+          .to include('unknown encoding name - foobar')
+      end
+    end
+
     shared_examples 'invalid parser_engine' do
       it 'raises ArgumentError' do
         expect { processed_source }.to raise_error(ArgumentError) do |e|


### PR DESCRIPTION
This specific exception has been added only in the most recent release. Previously it threw an `ArgumentError`. PR in parser: https://github.com/whitequark/parser/pull/999

This is not _really_ a syntax error: Running a file with an encoding like that produces the following output:

```
test.rb:1: unknown encoding name: foobar (ArgumentError)
```

RuboCop will report it as one though, since it will pick up the error from `parser_error`. I don't believe it is worth it to add extra logic to make a distinction here.