### PR TITLE
Fix a build error

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -106,7 +106,7 @@ jobs:
         internal_investigation: [null]
         include:
           - { rubocop: master, ruby: "3.0", os: ubuntu }
-          - { rubocop: "v1.57.2", ruby: "3.3", os: ubuntu }
+          - { rubocop: "v1.61.0", ruby: "3.3", os: ubuntu }
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR resolves the following CI error with RuboCop 1.61.0:

```console
$ bundle exec rake spec
(snip)

==> Failed Examples

rspec './spec/rubocop/version_spec.rb[1:2:2:1]' # RuboCop::Version.extension_versions when extensions are required returns the extensions
rspec './spec/rubocop/version_spec.rb[1:2:4:1]' # RuboCop::Version.extension_versions with an obsolete config returns the extensions
rspec './spec/rubocop/version_spec.rb[1:2:5:1]' # RuboCop::Version.extension_versions with an invalid cop in config returns the extensions
rspec './spec/rubocop/cli/options_spec.rb[1:5:2:1]' # RuboCop::CLI options -V when requiring extension cops shows with version of extension cops
rspec './spec/rubocop/cli/options_spec.rb[1:5:4:1]' # RuboCop::CLI options -V when requiring redundant extension cop shows with version of each extension cop once
rspec './spec/rubocop/cli/options_spec.rb[1:5:3:1]' # RuboCop::CLI options -V when requiring extension cops in multiple layers shows with version of extension cops
```

https://github.com/rubocop/rubocop-ast/actions/runs/9497558652/job/26350378083