### PR TITLE
Lift the deprecation from `ArrayNode#each_value`

### DIFF
--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -17,7 +17,11 @@ module RuboCop
       # @return [Array<Node>] an array of value nodes
       alias values children
 
-      # @deprecated Use `values.each` (a.k.a. `children.each`)
+      # Calls the given block for each `value` node in the `array` literal.
+      # If no block is given, an `Enumerator` is returned.
+      #
+      # @return [self] if a block is given
+      # @return [Enumerator] if no block is given
       def each_value(&block)
         return to_enum(__method__) unless block
 


### PR DESCRIPTION
This PR lifts the deprecation from `ArrayNode#each_value` for the following reasons:

1. `HashNode#each_value` and `HashNode#each_key` are not deprecated.

- `HashNode#each_value` ... https://github.com/rubocop/rubocop-ast/blob/v1.31.3/lib/rubocop/ast/node/hash_node.rb#L76-L89
- `HashNode#each_key` ... https://github.com/rubocop/rubocop-ast/blob/v1.31.3/lib/rubocop/ast/node/hash_node.rb#L52-L65

2. `node.values.each` is recommended by `Style/HashEachMethods` cop to be replaced with `each_value` instead of `values.each`. And `node.each_value do |value|` is clearer in intent than `node.children.each do |value|`.

Since it is a soft deprecation in documentation only, it has not been added to the changelog.