### PR TITLE
Return parser error on parsing invalid encoding regexp

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -208,15 +208,13 @@ module RuboCop
 
         begin
           @buffer.source = source
+          @ast, @comments, @tokens = tokenize(create_parser(ruby_version, parser_engine))
         rescue EncodingError, Parser::UnknownEncodingInMagicComment => e
           @parser_error = e
           @ast = nil
           @comments = []
           @tokens = []
-          return
         end
-
-        @ast, @comments, @tokens = tokenize(create_parser(ruby_version, parser_engine))
       end
 
       def tokenize(parser)

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
+    context 'when parsing invalid encoding regexp', broken_on: :prism do
+      let(:source) { '/あ/n' }
+
+      it 'returns a parser error' do
+        expect(processed_source.parser_error).to be_a(EncodingError)
+      end
+    end
+
     shared_examples 'invalid parser_engine' do
       it 'raises ArgumentError' do
         expect { processed_source }.to raise_error(ArgumentError) do |e|


### PR DESCRIPTION
I noticed that if I give `ProcessedSource` code that contains an invalid encoding regular expression (e.g. `/あ/n`), it does not catch this encoding error. 

```
$ ruby -r rubocop-ast -e "RuboCop::AST::ProcessedSource.new('/あ/n', 3.3)"
/home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/builders/default.rb:2261:in `encode': U+3042 from UTF-8 to ASCII-8BIT (Encoding::UndefinedConversionError)
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/builders/default.rb:2261:in `static_regexp'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/builders/default.rb:428:in `regexp_compose'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/ruby33.rb:11614:in `_reduce_572'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/racc-1.8.0/lib/racc/parser.rb:263:in `_racc_do_parse_c'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/racc-1.8.0/lib/racc/parser.rb:263:in `do_parse'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/base.rb:190:in `parse'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/parser-3.3.4.0/lib/parser/base.rb:238:in `tokenize'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rubocop-ast-1.31.3/lib/rubocop/ast/processed_source.rb:225:in `tokenize'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rubocop-ast-1.31.3/lib/rubocop/ast/processed_source.rb:220:in `parse'
        from /home/r7kamura/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/rubocop-ast-1.31.3/lib/rubocop/ast/processed_source.rb:48:in `initialize'
        from -e:1:in `new'
        from -e:1:in `<main>'
```

This exception is raised from `#tokenize`, so why not catch the exception raised here as well?