### PR TITLE
Link the node pattern debugger in docs

### DIFF
--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -633,7 +633,8 @@ Curious about how it works?
 Check more details in the
 https://www.rubydoc.info/gems/rubocop-ast/RuboCop/AST/NodePattern[documentation]
 or browse the https://github.com/rubocop/rubocop-ast/blob/master/lib/rubocop/ast/node_pattern.rb[source code]
-directly. It's easy to read and hack on.
+directly. It's easy to read and hack on. The https://nodepattern.herokuapp.com/[node pattern debugger]
+is an online tool where you can quickly try out patterns you create.
 
 The https://github.com/rubocop/rubocop-ast/blob/master/spec/rubocop/ast/node_pattern_spec.rb[specs]
 are also very useful to comprehend each feature.

--- a/docs/modules/ROOT/pages/node_pattern_compiler.adoc
+++ b/docs/modules/ROOT/pages/node_pattern_compiler.adoc
@@ -3,6 +3,8 @@
 This documentation is aimed at anyone wanting to understand / modify the `NodePattern` compiler.
 It assumes some familiarity with the syntax of https://github.com/rubocop/rubocop-ast/blob/master/docs/modules/ROOT/pages/node_pattern.adoc[`NodePattern`], as well as the AST produced by the `parser` gem.
 
+TIP: Use the https://nodepattern.herokuapp.com/[node pattern debugger] if you want to quickly try things out.
+
 == High level view
 
 The `NodePattern` compiler uses the same techniques as the `parser` gem:


### PR DESCRIPTION
It's an invaluable tool when trying to understand what the hell is going on (for me at least). When googling `rubocop node pattern debugger` it's the 6th result for me, while the hackers guide is the first. I think it makes sense to link it here, and in the more detailed guide as well.