### PR TITLE
Mark `RuboCop::AST::EnsureNode` as being in a void context.

### DIFF
--- a/changelog/change_mark_ensure_as_void_context.md
+++ b/changelog/change_mark_ensure_as_void_context.md
@@ -1,0 +1,1 @@
+* [#309](https://github.com/rubocop/rubocop-ast/pull/309): Mark `RuboCop::AST::EnsureNode` as being in a void context. ([@earlopain][])

--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -12,6 +12,14 @@ module RuboCop
       def body
         node_parts[1]
       end
+
+      # Checks whether this node body is a void context.
+      # Always `true` for `ensure`.
+      #
+      # @return [true] whether the `ensure` node body is a void context
+      def void_context?
+        true
+      end
     end
   end
 end

--- a/spec/rubocop/ast/ensure_node_spec.rb
+++ b/spec/rubocop/ast/ensure_node_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe RuboCop::AST::EnsureNode do
 
     it { expect(ensure_node.body).to be_sym_type }
   end
+
+  describe '#void_context?' do
+    let(:source) { 'begin; beginbody; ensure; ensurebody; end' }
+
+    it { expect(ensure_node).to be_void_context }
+  end
 end


### PR DESCRIPTION
`ensure` nodes are somewhat special in that their last expression will not get implicitly returned.

```rb
def foo(do_rescue:)
  puts "begin called"
  raise if do_rescue
  "begin"
rescue
  puts "rescue called"
  "rescue"
ensure
  puts "ensure called"
  "ensure"
end

puts foo(do_rescue: false)
puts "----"
puts foo(do_rescue: true)

# =>
# begin called
# ensure called
# begin
# ----
# begin called
# rescue called
# ensure called
# rescue
```

This change will make it possible to properly teach `Lint/Void` about it.