### PR TITLE
Fix `RuboCop::AST::DefNode#void_context?` to handle class methods called `initialize`

### DIFF
--- a/changelog/fix_def_node_void_context.md
+++ b/changelog/fix_def_node_void_context.md
@@ -1,0 +1,1 @@
+* [#310](https://github.com/rubocop/rubocop-ast/pull/310): Fix `RuboCop::AST::DefNode#void_context?` to handle class methods called `initialize`. ([@vlad-pisanov][])

--- a/lib/rubocop/ast/node/def_node.rb
+++ b/lib/rubocop/ast/node/def_node.rb
@@ -13,7 +13,7 @@ module RuboCop
       #
       # @return [Boolean] whether the `def` node body is a void context
       def void_context?
-        method?(:initialize) || assignment_method?
+        (def_type? && method?(:initialize)) || assignment_method?
       end
 
       # Checks whether this method definition node forwards its arguments

--- a/spec/rubocop/ast/def_node_spec.rb
+++ b/spec/rubocop/ast/def_node_spec.rb
@@ -324,6 +324,12 @@ RSpec.describe RuboCop::AST::DefNode do
       it { is_expected.to be_void_context }
     end
 
+    context 'with a class method called "initialize"' do
+      let(:source) { 'def self.initialize(bar); end' }
+
+      it { is_expected.not_to be_void_context }
+    end
+
     context 'with a regular assignment method' do
       let(:source) { 'def foo=(bar); end' }
 


### PR DESCRIPTION
Currently, `DefNode#void_context?` incorrectly returns `true` for class methods called `initialize`. This PR fixes this.

```ruby
# constructor: void context ✔️ 
def initialize
  42
end

# class method: not void context! ❌ 
def self.initialize
  42
end
```