### PR TITLE
Replace forwardable with explicit delegation for performance

### DIFF
--- a/lib/rubocop/ast.rb
+++ b/lib/rubocop/ast.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'parser'
-require 'forwardable'
 require 'set'
 
 require_relative 'ast/ext/range'

--- a/lib/rubocop/ast/node/mixin/collection_node.rb
+++ b/lib/rubocop/ast/node/mixin/collection_node.rb
@@ -4,13 +4,17 @@ module RuboCop
   module AST
     # A mixin that helps give collection nodes array polymorphism.
     module CollectionNode
-      extend Forwardable
-
       ARRAY_METHODS =
         (Array.instance_methods - Object.instance_methods - [:to_a]).freeze
       private_constant :ARRAY_METHODS
 
-      def_delegators :to_a, *ARRAY_METHODS
+      ARRAY_METHODS.each do |method|
+        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+          def #{method}(...)    # def key?(...)
+            to_a.#{method}(...) #   to_a.key?(...)
+          end                   # end
+        RUBY
+      end
     end
   end
 end

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -48,7 +48,6 @@ module RuboCop
         end
       end
 
-      extend Forwardable
       include MethodDefiner
       Invalid = Class.new(StandardError)
 
@@ -72,14 +71,24 @@ module RuboCop
 
       attr_reader :pattern, :ast, :match_code
 
-      def_delegators :@compiler, :captures, :named_parameters, :positional_parameters
-
       def initialize(str, compiler: Compiler.new)
         @pattern = str
         @ast = compiler.parser.parse(str)
         @compiler = compiler
         @match_code = @compiler.compile_as_node_pattern(@ast, var: VAR)
         @cache = {}
+      end
+
+      def captures
+        @compiler.captures
+      end
+
+      def named_parameters
+        @compiler.named_parameters
+      end
+
+      def positional_parameters
+        @compiler.positional_parameters
       end
 
       def match(*args, **rest, &block)

--- a/lib/rubocop/ast/node_pattern/compiler.rb
+++ b/lib/rubocop/ast/node_pattern/compiler.rb
@@ -9,7 +9,6 @@ module RuboCop
       # Doc on how this fits in the compiling process:
       #   /docs/modules/ROOT/pages/node_pattern.adoc
       class Compiler
-        extend Forwardable
         attr_reader :captures, :named_parameters, :positional_parameters, :binding
 
         def initialize
@@ -21,7 +20,9 @@ module RuboCop
           @atom_subcompiler = self.class::AtomSubcompiler.new(self)
         end
 
-        def_delegators :binding, :bind
+        def bind(...)
+          @binding.bind(...)
+        end
 
         def positional_parameter(number)
           @positional_parameters = number if number > @positional_parameters

--- a/lib/rubocop/ast/node_pattern/compiler/debug.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/debug.rb
@@ -133,7 +133,13 @@ module RuboCop
             @parser ||= Parser::WithMeta.new
           end
 
-          def_delegators :parser, :comments, :tokens
+          def comments
+            parser.comments
+          end
+
+          def tokens
+            parser.tokens
+          end
 
           # @api private
           module InstrumentationSubcompiler

--- a/lib/rubocop/ast/node_pattern/node.rb
+++ b/lib/rubocop/ast/node_pattern/node.rb
@@ -5,7 +5,6 @@ module RuboCop
     class NodePattern
       # Base class for AST Nodes of a `NodePattern`
       class Node < ::Parser::AST::Node
-        extend Forwardable
         include ::RuboCop::AST::Descendence
 
         MATCHES_WITHIN_SET = %i[symbol number string].to_set.freeze
@@ -95,7 +94,13 @@ module RuboCop
         # Node class for `$something`
         class Capture < Node
           # Delegate most introspection methods to it's only child
-          def_delegators :child, :arity, :rest?
+          def arity
+            child.arity
+          end
+
+          def rest?
+            child.rest?
+          end
 
           def capture?
             true


### PR DESCRIPTION
I'm doing performance profiling and was surprised for these to appear at all in the samples. Here are some numbers (3 warmup runs, 20 measured runs, cache used):

```
# with forwardable in both rubocop + rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile" 
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.169 s ±  0.016 s    [User: 0.976 s, System: 0.190 s]
  Range (min … max):    1.138 s …  1.198 s    20 runs
  
# with forwardable only in rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile" 
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.145 s ±  0.011 s    [User: 0.959 s, System: 0.185 s]
  Range (min … max):    1.131 s …  1.170 s    20 runs

# with forwardable in neither
$ hyperfine -w 3 -r 20 "bundle exec rubocop Rakefile" 
Benchmark 1: bundle exec rubocop Rakefile
  Time (mean ± σ):      1.136 s ±  0.020 s    [User: 0.950 s, System: 0.183 s]
  Range (min … max):    1.098 s …  1.168 s    20 runs
```

Overall ~ 3% faster
  
-------

Full run, also about 3%:

```
# with forwardable in both rubocop + rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop" 
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.704 s ±  0.018 s    [User: 1.903 s, System: 1.004 s]
  Range (min … max):    1.669 s …  1.742 s    20 runs
  
# with forwardable only in rubocop-ast
$ hyperfine -w 3 -r 20 "bundle exec rubocop" 
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.677 s ±  0.025 s    [User: 1.847 s, System: 0.988 s]
  Range (min … max):    1.640 s …  1.763 s    20 runs

# with forwardable in neither
$ hyperfine -w 3 -r 20 "bundle exec rubocop" 
Benchmark 1: bundle exec rubocop
  Time (mean ± σ):      1.656 s ±  0.020 s    [User: 1.817 s, System: 0.984 s]
  Range (min … max):    1.630 s …  1.700 s    20 runs
```

The impact of changing `rubocop-ast` is not as large as the one in `rubocop` but its something nontheless. I think this makes sense and the added code is not that complex.

Companion PR for rubocop: https://github.com/rubocop/rubocop/pull/13175

-----

I don't need an immediate release should this get merged. Numbers are not that impressive and its a hard sell for the changelog. I'm fine with waiting for some more substantial change at a later time.