### PR TITLE
Suppress a Ruby 3.4's obsoleted warning in test

### DIFF
--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -317,7 +317,15 @@ RSpec.describe RuboCop::AST::Node do
       end
 
       context 'with no interpolation' do
-        let(:src) { URI::DEFAULT_PARSER.make_regexp.inspect }
+        let(:src) do
+          # TODO: When supporting Ruby 3.3+ runtime, `URI::DEFAULT_PARSER` can be removed and
+          #       only `URI::RFC2396_PARSER` can be used.
+          if defined?(URI::RFC2396_PARSER)
+            URI::RFC2396_PARSER
+          else
+            URI::DEFAULT_PARSER
+          end.make_regexp.inspect
+        end
 
         it 'returns true' do
           expect(node).to be_pure


### PR DESCRIPTION
This PR suppresses the following Ruby 3.4's obsoleted warning in test:

```console
$ ruby -v
ruby 3.4.0dev (2024-09-01T11:00:13Z master eb144ef91e) [x86_64-darwin23]

$ bundle exec rspec spec/rubocop/ast/node_spec.rb:320
(snip)

/Users/koic/src/github.com/rubocop/rubocop-ast/spec/rubocop/ast/node_spec.rb:320:
warning: URI::RFC3986_PARSER.make_regexp is obsoleted. Use URI::RFC2396_PARSER.make_regexp explicitly.
```