### PR TITLE
Bump `simplecov`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,7 @@ gem 'prism', '>= 0.28.0'
 gem 'racc'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
-# Workaround for cc-test-reporter with SimpleCov 0.18.
-# Stop upgrading SimpleCov until the following issue will be resolved.
-# https://github.com/codeclimate/test-reporter/issues/418
-gem 'simplecov', '~> 0.10', '< 0.18'
+gem 'simplecov', '~> 0.20'
 
 if ENV.fetch('RUBOCOP_VERSION', nil) == 'none'
   # Set this way on CI


### PR DESCRIPTION
This was present all the way back when the gem was extracted but I don't think this is actually needed here.

For RuboCop, it was fixed here: https://github.com/rubocop/rubocop/pull/13071

Edit: Looks good https://github.com/rubocop/rubocop-ast/actions/runs/10753134155/job/29822235839?pr=316