### PR TITLE
Use Prism 1.1+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'oedipus_lex', '>= 2.6.0', require: false
-gem 'prism', '>= 0.28.0'
+gem 'prism', '>= 1.1.0'
 gem 'racc'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'

--- a/spec/rubocop/ast/wrapped_arguments_node.rb
+++ b/spec/rubocop/ast/wrapped_arguments_node.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'wrapped arguments node' do |keyword|
-  subject(:return_node) { parse_source(source).ast }
+  subject(:return_node) { parse_source(source).ast.body }
 
   describe '.new' do
     context 'without arguments' do
-      let(:source) { keyword }
+      let(:source) { "x { #{keyword} }" }
 
       it { is_expected.to be_a(described_class) }
     end
 
     context 'with arguments' do
-      let(:source) { "#{keyword} :foo" }
+      let(:source) { "x { #{keyword} :foo }" }
 
       it { is_expected.to be_a(described_class) }
     end
@@ -19,37 +19,37 @@ RSpec.shared_examples 'wrapped arguments node' do |keyword|
 
   describe '#arguments' do
     context 'with no arguments' do
-      let(:source) { keyword }
+      let(:source) { "x { #{keyword} }" }
 
       it { expect(return_node.arguments).to be_empty }
     end
 
     context 'with no arguments and braces' do
-      let(:source) { "#{keyword}()" }
+      let(:source) { "x { #{keyword}() }" }
 
       it { expect(return_node.arguments).to be_empty }
     end
 
     context 'with a single argument' do
-      let(:source) { "#{keyword} :foo" }
+      let(:source) { "x { #{keyword} :foo }" }
 
       it { expect(return_node.arguments.size).to eq(1) }
     end
 
     context 'with a single argument and braces' do
-      let(:source) { "#{keyword}(:foo)" }
+      let(:source) { "x { #{keyword}(:foo) }" }
 
       it { expect(return_node.arguments.size).to eq(1) }
     end
 
     context 'with a single splat argument' do
-      let(:source) { "#{keyword} *baz" }
+      let(:source) { "x { #{keyword} *baz }" }
 
       it { expect(return_node.arguments.size).to eq(1) }
     end
 
     context 'with multiple literal arguments' do
-      let(:source) { "#{keyword} :foo, :bar" }
+      let(:source) { "x { #{keyword} :foo, :bar }" }
 
       it { expect(return_node.arguments.size).to eq(2) }
     end


### PR DESCRIPTION
This PR fixes the following build failures when using Prism 1.1+.

```console
$ bundle exec prism_spec
(snip)

Failed examples:

rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:4:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with a single argument and braces
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:1:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with no arguments
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:3:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with a single argument
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:2:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with no arguments and braces
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:6:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with multiple literal arguments
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:2:5:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node #arguments with a single splat argument
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:1:1:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node .new without arguments is expected to be a kind of RuboCop::AST::NextNode
rspec './spec/rubocop/ast/next_node_spec.rb[1:1:1:2:1]'
# RuboCop::AST::NextNode behaves like wrapped arguments node .new with arguments is expected to be a kind of RuboCop::AST::NextNode
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:5:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with a single splat argument
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:6:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with multiple literal arguments
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:1:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with no arguments
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:4:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with a single argument and braces
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:3:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with a single argument
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:2:2:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node #arguments with no arguments and braces
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:1:2:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node .new with arguments is expected to be a kind of RuboCop::AST::BreakNode
rspec './spec/rubocop/ast/break_node_spec.rb[1:1:1:1:1]'
# RuboCop::AST::BreakNode behaves like wrapped arguments node .new without arguments is expected to be a kind of RuboCop::AST::BreakNode
```

This is due to Prism 1.1 providing the correct behavior equivalent to Ruby's parse.y.

As of Ruby 3.3, using `next` and `break` at the top level results in a syntax error. This PR ensures proper validation by enclosing them in blocks for testing.