### PR TITLE
Fix RuboCop offense

### DIFF
--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -102,7 +102,7 @@ module RuboCop
       #
       # @return [Boolean] whether the `if` node has at least one `elsif` branch
       def elsif_conditional?
-        else_branch&.if_type? && else_branch&.elsif?
+        else_branch&.if_type? && else_branch.elsif?
       end
 
       # Returns the branch of the `if` node that gets evaluated when its


### PR DESCRIPTION
From https://github.com/rubocop/rubocop/pull/13312, probably

```
$ bundle exec rubocop
Inspecting 165 files
..............................W......................................................................................................................................

Offenses:

lib/rubocop/ast/node/if_node.rb:105:45: W: [Correctable] Lint/SafeNavigationConsistency: Use . instead of unnecessary &..
        else_branch&.if_type? && else_branch&.elsif?
                                            ^^

165 files inspected, 1 offense detected, 1 offense autocorrectable
```