### PR TITLE
Allow `non_bare_access_modifier_declaration?` to handle modifiers with multiple arguments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -92,3 +92,11 @@ RSpec/MultipleExpectations:
 # URISchemes: http, https
 Layout/LineLength:
   Max: 102
+
+# Offense count: 1
+# This cop supports unsafe autocorrection (--autocorrect-all).
+# Configuration parameters: EnforcedStyle, AllowModifiersOnSymbols, AllowModifiersOnAttrs.
+# SupportedStyles: inline, group
+Style/AccessModifierDeclarations:
+  Exclude:
+    - 'lib/rubocop/ast/node_pattern/compiler/sequence_subcompiler.rb'

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -281,7 +281,7 @@ module RuboCop
 
       # @!method non_bare_access_modifier_declaration?(node = self)
       def_node_matcher :non_bare_access_modifier_declaration?, <<~PATTERN
-        (send nil? {:public :protected :private :module_function} _)
+        (send nil? {:public :protected :private :module_function} _+)
       PATTERN
     end
   end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe RuboCop::AST::SendNode do
       it { expect(send_node).to be_access_modifier }
     end
 
+    context 'when node is a non-bare `module_function` with multiple arguments' do
+      let(:source) do
+        <<~RUBY
+          module Foo
+          >> module_function :foo, :bar <<
+          end
+        RUBY
+      end
+
+      it { expect(send_node).to be_access_modifier }
+    end
+
     context 'when node is not an access modifier' do
       let(:source) do
         <<~RUBY
@@ -202,6 +214,18 @@ RSpec.describe RuboCop::AST::SendNode do
         <<~RUBY
           module Foo
           >> module_function :foo <<
+          end
+        RUBY
+      end
+
+      it { expect(send_node).to be_non_bare_access_modifier }
+    end
+
+    context 'when node is a non-bare `module_function` with multiple arguments' do
+      let(:source) do
+        <<~RUBY
+          module Foo
+          >> module_function :foo, :bar <<
           end
         RUBY
       end


### PR DESCRIPTION
I noticed this when testing `Style/AccessModifierDeclarations`. When an access modifier has multiple arguments, `non_bare_access_modifier_declaration?` erroneously (IMO) returns false, which causes the cop to not recognize all cases it should.

The cop does not properly recognize (as a positive or negative, depends on the `AllowModifiersOnSymbols` configuration) this despite the examples for the cop including it.

```ruby
private :foo, :bar
```

I have a follow up PR to `Style/AccessModifierDeclarations` coming once this can be merged.