### PR TITLE
Introduce `lhs` and `rhs` aliases to assignment nodes for consistency.

### DIFF
--- a/lib/rubocop/ast/node/asgn_node.rb
+++ b/lib/rubocop/ast/node/asgn_node.rb
@@ -12,6 +12,7 @@ module RuboCop
       def name
         node_parts[0]
       end
+      alias lhs name
 
       # The expression being assigned to the variable.
       #
@@ -19,6 +20,7 @@ module RuboCop
       def expression
         node_parts[1]
       end
+      alias rhs expression
     end
   end
 end

--- a/lib/rubocop/ast/node/casgn_node.rb
+++ b/lib/rubocop/ast/node/casgn_node.rb
@@ -9,6 +9,7 @@ module RuboCop
       include ConstantNode
 
       alias name short_name
+      alias lhs short_name
 
       # The expression being assigned to the variable.
       #
@@ -16,6 +17,7 @@ module RuboCop
       def expression
         node_parts[2]
       end
+      alias rhs expression
     end
   end
 end

--- a/lib/rubocop/ast/node/op_asgn_node.rb
+++ b/lib/rubocop/ast/node/op_asgn_node.rb
@@ -10,6 +10,7 @@ module RuboCop
       def assignment_node
         node_parts[0]
       end
+      alias lhs assignment_node
 
       # The name of the variable being assigned as a symbol.
       #
@@ -31,6 +32,7 @@ module RuboCop
       def expression
         node_parts.last
       end
+      alias rhs expression
     end
   end
 end


### PR DESCRIPTION
The methods are already available for `masgn`, so this will allow all assignment node types to have the same two methods so that they can be dealt with in unison. Once released I've found some places in rubocop where more destructuring can be simplified.

Follows https://github.com/rubocop/rubocop/pull/13413#discussion_r1827267164

I didn't add tests for these aliases but am happy to if desired!