### PR TITLE
Extend `Node#const_name` to `casgn` nodes

### DIFF
--- a/changelog/new_extend_nodeconst_name_to_casgn_nodes.md
+++ b/changelog/new_extend_nodeconst_name_to_casgn_nodes.md
@@ -1,0 +1,1 @@
+* [#330](https://github.com/rubocop/rubocop-ast/pull/330): Extend `Node#const_name` to `casgn` nodes. ([@dvandersluis][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -312,13 +312,12 @@ module RuboCop
       def_node_matcher :str_content, '(str $_)'
 
       def const_name
-        return unless const_type?
+        return unless const_type? || casgn_type?
 
-        namespace, name = *self
         if namespace && !namespace.cbase_type?
-          "#{namespace.const_name}::#{name}"
+          "#{namespace.const_name}::#{short_name}"
         else
-          name.to_s
+          short_name.to_s
         end
       end
 

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -986,4 +986,66 @@ RSpec.describe RuboCop::AST::Node do
       end
     end
   end
+
+  describe '#const_name' do
+    context 'when given a `const` node' do
+      context 'FOO' do
+        let(:src) { 'FOO' }
+
+        it 'returns FOO' do
+          expect(node.const_name).to eq('FOO')
+        end
+      end
+
+      context 'FOO::BAR::BAZ' do
+        let(:src) { 'FOO::BAR::BAZ' }
+
+        it 'returns FOO::BAR::BAZ' do
+          expect(node.const_name).to eq('FOO::BAR::BAZ')
+        end
+      end
+
+      context '::FOO::BAR::BAZ' do
+        let(:src) { '::FOO::BAR::BAZ' }
+
+        it 'returns FOO::BAR::BAZ' do
+          expect(node.const_name).to eq('FOO::BAR::BAZ')
+        end
+      end
+    end
+
+    context 'when given a `casgn` node' do
+      context 'FOO = 1' do
+        let(:src) { 'FOO = 1' }
+
+        it 'returns FOO' do
+          expect(node.const_name).to eq('FOO')
+        end
+      end
+
+      context 'FOO::BAR::BAZ = 1' do
+        let(:src) { 'FOO::BAR::BAZ = 1' }
+
+        it 'returns FOO::BAR::BAZ' do
+          expect(node.const_name).to eq('FOO::BAR::BAZ')
+        end
+      end
+
+      context '::FOO::BAR::BAZ = 1' do
+        let(:src) { '::FOO::BAR::BAZ = 1' }
+
+        it 'returns FOO::BAR::BAZ' do
+          expect(node.const_name).to eq('FOO::BAR::BAZ')
+        end
+      end
+    end
+
+    context 'when given a `send` node' do
+      let(:src) { 'foo.bar' }
+
+      it 'return nil' do
+        expect(node.const_name).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now that `CasgnNode` was added in #204, we can extend `const_name` to `casgn` nodes as well. This allows code such as https://github.com/rubocop/rubocop/blob/736e8d699b5f632e7a05fd65788e28f23b2e3a67/lib/rubocop/cop/style/swap_values.rb#L84-L89 to be refactored out.