### PR TITLE
[Fix #331] Fix crash in `OpAsgnNode#name` when the lhs is a `send` or `csend` node

### DIFF
--- a/changelog/fix_fix_331_fix_crash_in_opasgnnodename_when.md
+++ b/changelog/fix_fix_331_fix_crash_in_opasgnnodename_when.md
@@ -1,0 +1,1 @@
+* [#331](https://github.com/rubocop/rubocop-ast/issue/331): [Fix #331] Fix crash in `OpAsgnNode#name` when the lhs is a `send` or `csend` node. ([@dvandersluis][])

--- a/lib/rubocop/ast/node/op_asgn_node.rb
+++ b/lib/rubocop/ast/node/op_asgn_node.rb
@@ -16,7 +16,7 @@ module RuboCop
       #
       # @return [Symbol] the name of the variable being assigned
       def name
-        assignment_node.name
+        assignment_node.call_type? ? assignment_node.method_name : assignment_node.name
       end
 
       # The operator being used for assignment as a symbol.

--- a/spec/rubocop/ast/op_asgn_node_spec.rb
+++ b/spec/rubocop/ast/op_asgn_node_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::AST::OpAsgnNode do
-  let(:op_asgn_node) { parse_source(source).ast }
+  let(:parsed_source) { parse_source(source) }
+  let(:op_asgn_node) { parsed_source.ast }
 
   describe '.new' do
     context 'with an `op_asgn_node` node' do
@@ -15,8 +16,21 @@ RSpec.describe RuboCop::AST::OpAsgnNode do
     subject { op_asgn_node.assignment_node }
 
     let(:source) { 'var += value' }
+    let(:node) { parsed_source.node }
 
     it { is_expected.to be_a(RuboCop::AST::AsgnNode) }
+
+    context 'when the LHS is a `send` node' do
+      let(:source) { '>> foo.var << += value' }
+
+      it { is_expected.to eq(node) }
+    end
+
+    context 'when the LHS is a `csend` node' do
+      let(:source) { '>> foo&.var << += value' }
+
+      it { is_expected.to eq(node) }
+    end
   end
 
   describe '#name' do
@@ -25,6 +39,18 @@ RSpec.describe RuboCop::AST::OpAsgnNode do
     let(:source) { 'var += value' }
 
     it { is_expected.to eq(:var) }
+
+    context 'when the LHS is a `send` node' do
+      let(:source) { 'foo.var += value' }
+
+      it { is_expected.to eq(:var) }
+    end
+
+    context 'when the LHS is a `csend` node' do
+      let(:source) { 'foo&.var += value' }
+
+      it { is_expected.to eq(:var) }
+    end
   end
 
   describe '#operator' do


### PR DESCRIPTION
`OpAsgnNode#assignment_node` could be a `send`/`csend` node, but this would cause `#name` to crash as call nodes do not respond to `name`.

Fixes #331.