### PR TITLE
Deprecate `EnsureNode#body` in favour of `EnsureNode#branch`

### DIFF
--- a/changelog/change_deprecate_ensurenodebody_in_favour_of.md
+++ b/changelog/change_deprecate_ensurenodebody_in_favour_of.md
@@ -1,0 +1,1 @@
+* [#337](https://github.com/rubocop/rubocop-ast/pull/337): Deprecate `EnsureNode#body` in favour of `EnsureNode#branch`. `EnsureNode#body` will be redefined in the next major version of rubocop-ast. ([@dvandersluis][])

--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -6,10 +6,31 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `ensure` nodes within RuboCop.
     class EnsureNode < Node
+      DEPRECATION_WARNING_LOCATION_CACHE = [] # rubocop:disable Style/MutableConstant
+      private_constant :DEPRECATION_WARNING_LOCATION_CACHE
+
       # Returns the body of the `ensure` clause.
       #
       # @return [Node, nil] The body of the `ensure`.
+      # @deprecated Use `EnsureNode#branch`
       def body
+        first_caller = caller(1..1).first
+
+        unless DEPRECATION_WARNING_LOCATION_CACHE.include?(first_caller)
+          warn '`EnsureNode#body` is deprecated and will be changed in the next major version of ' \
+               'rubocop-ast. Use `EnsureNode#branch` instead to get the body of the `ensure` branch.'
+          warn "Called from:\n#{caller.join("\n")}\n\n"
+
+          DEPRECATION_WARNING_LOCATION_CACHE << first_caller
+        end
+
+        branch
+      end
+
+      # Returns an the ensure branch in the exception handling statement.
+      #
+      # @return [Node, nil] the body of the ensure branch.
+      def branch
         node_parts[1]
       end
 

--- a/spec/rubocop/ast/ensure_node_spec.rb
+++ b/spec/rubocop/ast/ensure_node_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::AST::EnsureNode do
-  let(:ensure_node) { parse_source(source).ast.children.first }
+  let(:parsed_source) { parse_source(source) }
+  let(:ensure_node) { parsed_source.ast.children.first }
+  let(:node) { parsed_source.node }
 
   describe '.new' do
     let(:source) { 'begin; beginbody; ensure; ensurebody; end' }
@@ -9,10 +11,10 @@ RSpec.describe RuboCop::AST::EnsureNode do
     it { expect(ensure_node).to be_a(described_class) }
   end
 
-  describe '#body' do
-    let(:source) { 'begin; beginbody; ensure; :ensurebody; end' }
+  describe '#branch' do
+    let(:source) { 'begin; beginbody; ensure; >>ensurebody<<; end' }
 
-    it { expect(ensure_node.body).to be_sym_type }
+    it { expect(ensure_node.branch).to eq(node) }
   end
 
   describe '#rescue_node' do


### PR DESCRIPTION
Given the upcoming method change in #336, but also the fact that the tests of that PR cannot pass as-is since rubocop is still relying on the old definition, I thought it would make sense to deprecate `EnsureNode#body` and add `#branch` as an alias. Once released, I can update the uses of `EnsureNode#body` in rubocop (and extensions) without breaking anything, which will allow the "Main Gem Specs" CI to pass. 
