### PR TITLE
Don't show a deprecation warning for `EnsureNode#branch` just yet

### DIFF
--- a/changelog/fix_dont_emit_deprecation_just_yet.md
+++ b/changelog/fix_dont_emit_deprecation_just_yet.md
@@ -1,0 +1,1 @@
+* [#339](https://github.com/rubocop/rubocop-ast/pull/339): Do not emit a deprecation warning for `EnsureNode#body` to give RuboCop a chance to update its usage. `EnsureNode#body` will still be changed in the next major version of `rubocop-ast`. ([@earlopain][])

--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -6,24 +6,11 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `ensure` nodes within RuboCop.
     class EnsureNode < Node
-      DEPRECATION_WARNING_LOCATION_CACHE = [] # rubocop:disable Style/MutableConstant
-      private_constant :DEPRECATION_WARNING_LOCATION_CACHE
-
       # Returns the body of the `ensure` clause.
       #
       # @return [Node, nil] The body of the `ensure`.
       # @deprecated Use `EnsureNode#branch`
       def body
-        first_caller = caller(1..1).first
-
-        unless DEPRECATION_WARNING_LOCATION_CACHE.include?(first_caller)
-          warn '`EnsureNode#body` is deprecated and will be changed in the next major version of ' \
-               'rubocop-ast. Use `EnsureNode#branch` instead to get the body of the `ensure` branch.'
-          warn "Called from:\n#{caller.join("\n")}\n\n"
-
-          DEPRECATION_WARNING_LOCATION_CACHE << first_caller
-        end
-
         branch
       end
 


### PR DESCRIPTION
There currently is no RuboCop version that will not show this warning.
Somehow this did not cross my mind while looking at the other PR...

This can be reverted after RuboCop and its extensions are updated and released  to use the non-deprecated method.