### PR TITLE
Handle anonymous splats in `MlhsNode`

### DIFF
--- a/changelog/fix_anon_splat_for_mlhs.md
+++ b/changelog/fix_anon_splat_for_mlhs.md
@@ -1,0 +1,1 @@
+* [#340](https://github.com/rubocop/rubocop-ast/pull/340): Handle anonymous splats in `MlhsNode`. ([@earlopain][])

--- a/lib/rubocop/ast/node/mlhs_node.rb
+++ b/lib/rubocop/ast/node/mlhs_node.rb
@@ -8,13 +8,15 @@ module RuboCop
     class MlhsNode < Node
       # Returns all the assignment nodes on the left hand side (LHS) of a multiple assignment.
       # These are generally assignment nodes (`lvasgn`, `ivasgn`, `cvasgn`, `gvasgn`, `casgn`)
-      # but can also be `send` nodes in case of `foo.bar, ... =` or `foo[:bar], ... =`.
+      # but can also be `send` nodes in case of `foo.bar, ... =` or `foo[:bar], ... =`,
+      # or a `splat` node for `*, ... =`.
       #
       # @return [Array<Node>] the assignment nodes of the multiple assignment LHS
       def assignments
         child_nodes.flat_map do |node|
           if node.splat_type?
-            node.child_nodes.first
+            # Anonymous splats have no children
+            node.child_nodes.first || node
           elsif node.mlhs_type?
             node.assignments
           else

--- a/spec/rubocop/ast/mlhs_node_spec.rb
+++ b/spec/rubocop/ast/mlhs_node_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe RuboCop::AST::MlhsNode do
       it { is_expected.to eq([s(:lvasgn, :x), s(:lvasgn, :y)]) }
     end
 
+    context 'with an anonymous splat' do
+      let(:source) { 'x, * = z' }
+
+      it { is_expected.to eq([s(:lvasgn, :x), s(:splat)]) }
+    end
+
     context 'with nested `mlhs` nodes' do
       let(:source) { 'a, (b, c) = z' }
 


### PR DESCRIPTION
Ref: https://github.com/rubocop/rubocop/issues/13505

I checked what the cop was previously expecting here, before https://github.com/rubocop/rubocop/pull/13422

I'm not sure if a `splat` makes much sense here, but nil seems even more unexpected.

cc @dvandersluis 