### PR TITLE
Add `StrNode#single_quoted?`, `StrNode#double_quoted?` and `StrNode#percent_literal?` to simplify checking for string delimiters

### DIFF
--- a/changelog/change_add_strnodepercent_literal_to_simplify.md
+++ b/changelog/change_add_strnodepercent_literal_to_simplify.md
@@ -1,0 +1,1 @@
+* [#343](https://github.com/rubocop/rubocop-ast/pull/343): Add `StrNode#single_quoted?`, `StrNode#double_quoted?` and `StrNode#percent_literal?` to simplify checking for string delimiters. ([@dvandersluis][])

--- a/lib/rubocop/ast/node/str_node.rb
+++ b/lib/rubocop/ast/node/str_node.rb
@@ -8,12 +8,48 @@ module RuboCop
     class StrNode < Node
       include BasicLiteralNode
 
+      PERCENT_LITERAL_TYPES = {
+        :% => /\A%(?=[^a-zA-Z])/,
+        :q => /\A%q/,
+        :Q => /\A%Q/
+      }.freeze
+
+      def single_quoted?
+        loc_is?(:begin, "'")
+      end
+
+      def double_quoted?
+        loc_is?(:begin, '"')
+      end
+
       def character_literal?
         loc_is?(:begin, '?')
       end
 
       def heredoc?
         loc.is_a?(Parser::Source::Map::Heredoc)
+      end
+
+      # Checks whether the string literal is delimited by percent brackets.
+      #
+      # @overload percent_literal?
+      #   Check for any string percent literal.
+      #
+      # @overload percent_literal?(type)
+      #   Check for a string percent literal of type `type`.
+      #
+      # @param type [Symbol] an optional percent literal type
+      #
+      # @return [Boolean] whether the string is enclosed in percent brackets
+      def percent_literal?(type = nil)
+        opening_delimiter = loc.begin if loc.respond_to?(:begin)
+        return false unless opening_delimiter
+
+        if type
+          opening_delimiter.source.match?(PERCENT_LITERAL_TYPES.fetch(type))
+        else
+          opening_delimiter.source.start_with?('%')
+        end
       end
     end
   end

--- a/spec/rubocop/ast/dstr_node_spec.rb
+++ b/spec/rubocop/ast/dstr_node_spec.rb
@@ -35,4 +35,73 @@ RSpec.describe RuboCop::AST::DstrNode do
       it { is_expected.to eq('foo bar baz') }
     end
   end
+
+  describe '#single_quoted?' do
+    context 'with a double-quoted string' do
+      let(:source) { '"#{foo}"' }
+
+      it { is_expected.not_to be_single_quoted }
+    end
+
+    context 'with a %() delimited string' do
+      let(:source) { '%(#{foo})' }
+
+      it { is_expected.not_to be_single_quoted }
+    end
+
+    context 'with a %Q() delimited string' do
+      let(:source) { '%Q(#{foo})' }
+
+      it { is_expected.not_to be_single_quoted }
+    end
+  end
+
+  describe '#double_quoted?' do
+    context 'with a double-quoted string' do
+      let(:source) { '"#{foo}"' }
+
+      it { is_expected.to be_double_quoted }
+    end
+
+    context 'with a %() delimited string' do
+      let(:source) { '%(#{foo})' }
+
+      it { is_expected.not_to be_double_quoted }
+    end
+
+    context 'with a %Q() delimited string' do
+      let(:source) { '%Q(#{foo})' }
+
+      it { is_expected.not_to be_double_quoted }
+    end
+  end
+
+  describe '#percent_literal?' do
+    context 'with a quoted string' do
+      let(:source) { '"#{foo}"' }
+
+      it { is_expected.not_to be_percent_literal }
+      it { is_expected.not_to be_percent_literal(:%) }
+      it { is_expected.not_to be_percent_literal(:q) }
+      it { is_expected.not_to be_percent_literal(:Q) }
+    end
+
+    context 'with a %() delimited string' do
+      let(:source) { '%(#{foo})' }
+
+      it { is_expected.to be_percent_literal }
+      it { is_expected.to be_percent_literal(:%) }
+      it { is_expected.not_to be_percent_literal(:q) }
+      it { is_expected.not_to be_percent_literal(:Q) }
+    end
+
+    context 'with a %Q() delimited string' do
+      let(:source) { '%Q(#{foo})' }
+
+      it { is_expected.to be_percent_literal }
+      it { is_expected.not_to be_percent_literal(:%) }
+      it { is_expected.not_to be_percent_literal(:q) }
+      it { is_expected.to be_percent_literal(:Q) }
+    end
+  end
 end


### PR DESCRIPTION
 This would allow rubocop code that checks for different string delimiter types to do so in a simpler way.

I took inspiration from `ArrayNode#percent_literal?` for the interface for `StrNode#percent_literal?`.