### PR TITLE
`reminds` probably was meant to be `resembles`

### DIFF
--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -3,7 +3,7 @@
 Node pattern is a DSL to help find specific nodes in the Abstract Syntax Tree
 using a simple string.
 
-It reminds the simplicity of regular expressions but used to find specific
+It resembles the simplicity of regular expressions but used to find specific
 nodes of Ruby code.
 
 == History

--- a/docs/modules/ROOT/pages/node_pattern.adoc
+++ b/docs/modules/ROOT/pages/node_pattern.adoc
@@ -3,7 +3,7 @@
 Node pattern is a DSL to help find specific nodes in the Abstract Syntax Tree
 using a simple string.
 
-It resembles the simplicity of regular expressions but used to find specific
+It resembles the simplicity of regular expressions but is used to find specific
 nodes of Ruby code.
 
 == History


### PR DESCRIPTION
I believe there's a typo in the `node_pattern` docs. This change fixes the sentence. 