### PR TITLE
Better handle `LoadError`s from prism

### DIFF
--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -318,7 +318,7 @@ module RuboCop
         require "prism/translation/parser#{version.to_s.delete('.')}"
       rescue LoadError
         warn <<~MESSAGE
-          Error: Unable to load Prism Parser for Ruby #{version}.
+          Error: Unable to load Prism parser for Ruby #{version}.
           * If you're using Bundler and don't yet have `gem 'prism'` as a dependency, add it now.
           * If you're using Bundler and already have `gem 'prism'` as a dependency, update it to the most recent version.
           * If you don't use Bundler, run `gem update prism`.


### PR DESCRIPTION
There are two different cases that may happen:

Prism was compiled in the past, the user updated the ruby version, but it still points to the same library
> linked to incompatible /home/user/.rbenv/versions/3.4.1/lib/libruby.so.3.4 - /home/user/Documents/ruby-prism/lib/prism/prism.so

In that case, bubble up the original error.

On the other hand, since prism is no dependency, users may run older verions that are missing translator classes. In that case, show a message what they should do.
prism is a default gem since 3.3, so you can even use it without adding it to your gemfile.