### PR TITLE
Fix current RuboCop offenses

### DIFF
--- a/lib/rubocop/ast/node/mixin/predicate_operator_node.rb
+++ b/lib/rubocop/ast/node/mixin/predicate_operator_node.rb
@@ -14,6 +14,11 @@ module RuboCop
       SEMANTIC_OR = 'or'
       private_constant :SEMANTIC_OR
 
+      LOGICAL_OPERATORS = [LOGICAL_AND, LOGICAL_OR].freeze
+      private_constant :LOGICAL_OPERATORS
+      SEMANTIC_OPERATORS = [SEMANTIC_AND, SEMANTIC_OR].freeze
+      private_constant :SEMANTIC_OPERATORS
+
       # Returns the operator as a string.
       #
       # @return [String] the operator
@@ -25,14 +30,14 @@ module RuboCop
       #
       # @return [Boolean] whether this is a logical operator
       def logical_operator?
-        operator == LOGICAL_AND || operator == LOGICAL_OR
+        LOGICAL_OPERATORS.include?(operator)
       end
 
       # Checks whether this is a semantic operator.
       #
       # @return [Boolean] whether this is a semantic operator
       def semantic_operator?
-        operator == SEMANTIC_AND || operator == SEMANTIC_OR
+        SEMANTIC_OPERATORS.include?(operator)
       end
     end
   end

--- a/lib/rubocop/ast/token.rb
+++ b/lib/rubocop/ast/token.rb
@@ -5,6 +5,7 @@ module RuboCop
     # A basic wrapper around Parser's tokens.
     class Token
       LEFT_PAREN_TYPES = %i[tLPAREN tLPAREN2].freeze
+      LEFT_CURLY_TYPES = %i[tLCURLY tLAMBEG].freeze
 
       attr_reader :pos, :type, :text
 
@@ -83,7 +84,7 @@ module RuboCop
       end
 
       def left_curly_brace?
-        type == :tLCURLY || type == :tLAMBEG
+        LEFT_CURLY_TYPES.include?(type)
       end
 
       def right_curly_brace?


### PR DESCRIPTION
```
Offenses:

lib/rubocop/ast/node/mixin/predicate_operator_node.rb:28:9: C: [Correctable] Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
        operator == LOGICAL_AND || operator == LOGICAL_OR
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/ast/node/mixin/predicate_operator_node.rb:35:9: C: [Correctable] Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
        operator == SEMANTIC_AND || operator == SEMANTIC_OR
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/ast/token.rb:86:9: C: [Correctable] Style/MultipleComparison: Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
        type == :tLCURLY || type == :tLAMBEG
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Although these constants are private, they are referenced in `OrNode` and `AndNode`