### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.7, "3.0", 3.1, 3.2, 3.3, head]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3, 3.4, head]
         coverage: [null]
         modern: [null]
         title: [null]
@@ -105,7 +105,7 @@ jobs:
         internal_investigation: [null]
         include:
           - { rubocop: master, ruby: "3.0", os: ubuntu }
-          - { rubocop: "v1.61.0", ruby: "3.3", os: ubuntu }
+          - { rubocop: "v1.69.2", ruby: "3.4", os: ubuntu }
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Ruby 3.4 has been released, and support for Ruby 3.4.0 and 3.4.1 was added to setup-ruby: https://github.com/ruby/setup-ruby/pull/679

https://github.com/rubocop/rubocop/pull/13297 is required to pass the following spec on both Ruby versions before 3.3 and 3.4 and later:

```console
  1) RuboCop::ConfigStore.for always uses config specified in command line
     Failure/Error: expect(config_store.for('file1')).to eq('merged {:options_config=>true}')

       expected: "merged {:options_config=>true}"
            got: "merged {options_config: true}"

       (compared using ==)
     # ./spec/rubocop/config_store_spec.rb:25:in 'block (3 levels) in <top (required)>'
     # tasks/spec_runner.rake:83:in 'RuboCop::SpecRunner::ParallelRunner#run_worker'
     # tasks/spec_runner.rake:38:in 'block in RuboCop::SpecRunner#run_specs'
     # tasks/spec_runner.rake:52:in 'RuboCop::SpecRunner#with_encoding'
     # tasks/spec_runner.rake:36:in 'RuboCop::SpecRunner#run_specs'
     # tasks/spec_runner.rake:164:in 'block in <top (required)>'
```

https://github.com/rubocop/rubocop-ast/actions/runs/12529029565/job/34944210256

Therefore, RuboCop used in `rubocop_specs` has been updated to v1.69.2, the version released with Ruby 3.4.
