### PR TITLE
CI against an older RuboCop version

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -104,8 +104,8 @@ jobs:
         rubocop: [master]
         internal_investigation: [null]
         include:
-          - { rubocop: master, ruby: "3.0", os: ubuntu }
-          - { rubocop: "v1.69.2", ruby: "3.4", os: ubuntu }
+          - { rubocop: master, ruby: "3.4", os: ubuntu }
+          - { rubocop: "v1.61.0", ruby: "2.7", os: ubuntu }
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
1.69.2 was only just recently released. Since 3.4 changed hash inspect formatting, some specs now fail.
Instead, bump the ruby version against rubocop master which is equiped to handle these changes.

Now it again tests against a version that is about one year old. 1.61 is the minimum because of https://github.com/rubocop/rubocop-ast/pull/296