### PR TITLE
Prism custom builder

### DIFF
--- a/changelog/change_prism_builder.md
+++ b/changelog/change_prism_builder.md
@@ -1,0 +1,1 @@
+* [#354](https://github.com/rubocop/rubocop-ast/pull/354): Use `Prism::Translation::Parser::Builder` when parsing with prism. ([@earlopain][])

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -2,20 +2,13 @@
 
 module RuboCop
   module AST
-    # `RuboCop::AST::Builder` is an AST builder that is utilized to let `Parser`
-    # generate ASTs with {RuboCop::AST::Node}.
-    #
-    # @example
-    #   buffer = Parser::Source::Buffer.new('(string)')
-    #   buffer.source = 'puts :foo'
-    #
-    #   builder = RuboCop::AST::Builder.new
-    #   require 'parser/ruby25'
-    #   parser = Parser::Ruby25.new(builder)
-    #   root_node = parser.parse(buffer)
-    class Builder < Parser::Builders::Default
-      self.emit_forward_arg = true if respond_to?(:emit_forward_arg=)
-      self.emit_match_pattern = true if respond_to?(:emit_match_pattern=)
+    # Common functionality between the parser and prism builder
+    # @api private
+    module BuilderExtensions
+      def self.included(base)
+        base.emit_forward_arg = true
+        base.emit_match_pattern = true
+      end
 
       # @api private
       NODE_MAP = {
@@ -107,7 +100,7 @@ module RuboCop
         node_klass(type).new(type, children, location: source_map)
       end
 
-      # TODO: Figure out what to do about literal encoding handling...
+      # Overwrite the base method to allow strings with invalid encoding
       # More details here https://github.com/whitequark/parser/issues/283
       def string_value(token)
         value(token)
@@ -118,6 +111,21 @@ module RuboCop
       def node_klass(type)
         NODE_MAP[type] || Node
       end
+    end
+
+    # `RuboCop::AST::Builder` is an AST builder that is utilized to let `Parser`
+    # generate ASTs with {RuboCop::AST::Node}.
+    #
+    # @example
+    #   buffer = Parser::Source::Buffer.new('(string)')
+    #   buffer.source = 'puts :foo'
+    #
+    #   builder = RuboCop::AST::Builder.new
+    #   require 'parser/ruby25'
+    #   parser = Parser::Ruby25.new(builder)
+    #   root_node = parser.parse(buffer)
+    class Builder < Parser::Builders::Default
+      include BuilderExtensions
     end
   end
 end

--- a/lib/rubocop/ast/builder_prism.rb
+++ b/lib/rubocop/ast/builder_prism.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module AST
+    # A parser builder, based on the one provided by prism,
+    # which is capable of emitting AST for more recent Rubies.
+    class BuilderPrism < Prism::Translation::Parser::Builder
+      include BuilderExtensions
+    end
+  end
+end

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -326,6 +326,17 @@ module RuboCop
         end
       end
 
+      def builder_class(parser_engine)
+        case parser_engine
+        when :parser_whitequark
+          RuboCop::AST::Builder
+        when :parser_prism
+          require_prism
+          require_relative 'builder_prism'
+          RuboCop::AST::BuilderPrism
+        end
+      end
+
       # Prism is a native extension, a `LoadError` will be raised if linked to an incompatible
       # Ruby version. Only raise if it really was caused by Prism not being present.
       def require_prism
@@ -353,7 +364,7 @@ module RuboCop
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def create_parser(ruby_version, parser_engine, prism_result)
-        builder = RuboCop::AST::Builder.new
+        builder = builder_class(parser_engine).new
 
         parser_class = parser_class(ruby_version, parser_engine)
 

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -314,10 +314,10 @@ module RuboCop
 
           case ruby_version
           when 3.3
-            require_prism_translation_parser(ruby_version)
+            require 'prism/translation/parser33'
             Prism::Translation::Parser33
           when 3.4
-            require_prism_translation_parser(ruby_version)
+            require 'prism/translation/parser34'
             Prism::Translation::Parser34
           else
             raise ArgumentError, 'RuboCop supports target Ruby versions 3.3 and above with Prism. ' \
@@ -339,28 +339,28 @@ module RuboCop
 
       # Prism is a native extension, a `LoadError` will be raised if linked to an incompatible
       # Ruby version. Only raise if it really was caused by Prism not being present.
+      # rubocop:disable Metrics/MethodLength
       def require_prism
         require 'prism'
+        required_prism_version = '1.4.0'
+        if required_prism_version > Prism::VERSION
+          # While Prism is not yet a dependency, users may run with outdated versions that
+          # don't have all the parsers.
+          warn <<~MESSAGE
+            Error: Prism version #{Prism::VERSION} was loaded, but rubocop-ast requires #{required_prism_version}.
+            * If you're using Bundler and don't yet have `gem 'prism'` as a dependency, add it now.
+            * If you're using Bundler and already have `gem 'prism'` as a dependency, update it to the most recent version.
+            * If you don't use Bundler, run `gem update prism`.
+          MESSAGE
+          exit!
+        end
       rescue LoadError => e
         raise unless e.path == 'prism'
 
         warn "Error: Unable to load Prism. Add `gem 'prism'` to your Gemfile."
         exit!
       end
-
-      # While Prism is not yet a dependency, users may run with outdated versions that
-      # don't have all the parsers.
-      def require_prism_translation_parser(version)
-        require "prism/translation/parser#{version.to_s.delete('.')}"
-      rescue LoadError
-        warn <<~MESSAGE
-          Error: Unable to load Prism parser for Ruby #{version}.
-          * If you're using Bundler and don't yet have `gem 'prism'` as a dependency, add it now.
-          * If you're using Bundler and already have `gem 'prism'` as a dependency, update it to the most recent version.
-          * If you don't use Bundler, run `gem update prism`.
-        MESSAGE
-        exit!
-      end
+      # rubocop:enable Metrics/MethodLength
 
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def create_parser(ruby_version, parser_engine, prism_result)


### PR DESCRIPTION
Context: https://github.com/ruby/prism/pull/3443

I'd like for prism to emit ast for new ruby features, like `it`. It's incredibly easy for prism to emit `itblock`, it just needs a custom builder, with a few lines changed to do so. But since `rubocop-ast` already uses its own custom builder, they need to play nicely together for it to work.

The PR for prism just adds the builder class, without any changes. I'd like to explore that after this.