### PR TITLE
Add `Node#any_block_type?` to determine if a node is either a block or numblock

### DIFF
--- a/changelog/new_group_block.md
+++ b/changelog/new_group_block.md
@@ -1,0 +1,1 @@
+* [#356](https://github.com/rubocop/rubocop-ast/pull/356): Added `:any_block` as an alias for `:block` and `:numblock`, use it with `Node#any_block_type?`. Also available in node patterns: `{block numblock}` can become `any_block`. ([@earlopain][])

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -165,7 +165,7 @@ module RuboCop
       #
       # @return [Boolean] whether the dispatched method has a block
       def block_literal?
-        (parent&.block_type? || parent&.numblock_type?) && eql?(parent.send_node)
+        parent&.any_block_type? && eql?(parent.send_node)
       end
 
       # Checks whether this node is an arithmetic operation
@@ -260,7 +260,7 @@ module RuboCop
           ^{                                       # or the parent is...
             sclass class module class_constructor? # a class-like node
             [ {                                    # or some "wrapper"
-                kwbegin begin block numblock
+                kwbegin begin any_block
                 (if _condition <%0 _>)  # note: we're excluding the condition of `if` nodes
               }
               #in_macro_scope?                     # that is itself in a macro scope


### PR DESCRIPTION
There are many instances where you just want to know if it's a block and don't care about what type it is: https://github.com/search?q=org%3Arubocop+%2Fblock.*numblock%2F&type=code

Should `itblock` be added, most of these will need to add yet another block type. With this, they can instead use this.

I had a bit of trouble choosing a good name. Maybe you have a better one to use?