### PR TITLE
Support node groups in `Node#each_descendant` and similar traversal methods

### DIFF
--- a/changelog/change_allow_groups_for_traversal.md
+++ b/changelog/change_allow_groups_for_traversal.md
@@ -1,0 +1,1 @@
+* [#357](https://github.com/rubocop/rubocop-ast/pull/357): Support node groups in `Node#each_descendant` and similar traversal methods. ([@earlopain][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -76,9 +76,6 @@ module RuboCop
       OPERATOR_KEYWORDS = %i[and or].to_set.freeze
       # @api private
       SPECIAL_KEYWORDS = %w[__FILE__ __LINE__ __ENCODING__].to_set.freeze
-      # @api private
-      ARGUMENT_TYPES = %i[arg optarg restarg kwarg kwoptarg kwrestarg
-                          blockarg forward_arg shadowarg].to_set.freeze
 
       LITERAL_RECURSIVE_METHODS = (COMPARISON_OPERATORS + %i[* ! <=>]).freeze
       LITERAL_RECURSIVE_TYPES = (OPERATOR_KEYWORDS + COMPOSITE_LITERALS + %i[begin pair]).freeze
@@ -98,7 +95,7 @@ module RuboCop
         kwrestarg: :argument,
         blockarg: :argument,
         forward_arg: :argument,
-        shardowarg: :argument,
+        shadowarg: :argument,
 
         true: :boolean,
         false: :boolean,
@@ -657,8 +654,7 @@ module RuboCop
         last_node = self
 
         while (current_node = last_node.parent)
-          yield current_node if types.empty? ||
-                                types.include?(current_node.type)
+          yield current_node if types.empty? || current_node.type?(*types)
           last_node = current_node
         end
       end

--- a/lib/rubocop/ast/node/args_node.rb
+++ b/lib/rubocop/ast/node/args_node.rb
@@ -32,7 +32,7 @@ module RuboCop
       #
       # @return [Array<Node>] array of argument nodes.
       def argument_list
-        each_descendant(*ARGUMENT_TYPES).to_a.freeze
+        each_descendant(:argument).to_a.freeze
       end
     end
   end

--- a/lib/rubocop/ast/node/mixin/descendence.rb
+++ b/lib/rubocop/ast/node/mixin/descendence.rb
@@ -25,7 +25,7 @@ module RuboCop
         children.each do |child|
           next unless child.is_a?(::AST::Node)
 
-          yield child if types.empty? || types.include?(child.type)
+          yield child if types.empty? || child.type?(*types)
         end
 
         self
@@ -95,7 +95,7 @@ module RuboCop
       def each_node(*types, &block)
         return to_enum(__method__, *types) unless block
 
-        yield self if types.empty? || types.include?(type)
+        yield self if types.empty? || type?(*types)
 
         visit_descendants(types, &block)
 
@@ -108,7 +108,7 @@ module RuboCop
         children.each do |child|
           next unless child.is_a?(::AST::Node)
 
-          yield child if types.empty? || types.include?(child.type)
+          yield child if types.empty? || child.type?(*types)
           child.visit_descendants(types, &block)
         end
       end


### PR DESCRIPTION
Sometimes it would be nice to do `each_child_node(:call)` instead of `each_child_node(:send, :csend)`. This nicely mirrors that you can already use these aliases when writing node patterns