### PR TITLE
[Fix #360] Fix an error when the `Array` core class contains a writer method

### DIFF
--- a/changelog/fix_array_writer_method.md
+++ b/changelog/fix_array_writer_method.md
@@ -1,0 +1,1 @@
+* [#360](https://github.com/rubocop/rubocop-ast/pull/360): Fix an error when the `Array` core class contains a writer method before `rubocop-ast` loaded. ([@earlopain][])

--- a/lib/rubocop/ast/utilities/simple_forwardable.rb
+++ b/lib/rubocop/ast/utilities/simple_forwardable.rb
@@ -5,11 +5,22 @@ module RuboCop
   module SimpleForwardable
     def def_delegators(accessor, *methods)
       methods.each do |method|
-        class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
-          def #{method}(...)           # def example(...)
-            #{accessor}.#{method}(...) #   foo.example(...)
-          end                          # end
-        RUBY
+        if method.end_with?('=') && method.to_s != '[]='
+          # Defining a delegator for `foo=` can't use `foo=(...)` because it is a
+          # syntax error. Fall back to doing a slower `public_send` instead.
+          # TODO: Use foo(method, ...) when Ruby 3.1 is required.
+          class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+            def #{method}(*args, **kwargs, &blk)                         # def example=(*args, **kwargs, &blk)
+              #{accessor}.public_send(:#{method}, *args, **kwargs, &blk) #   foo.public_send(:example=, *args, **kwargs, &blk)
+            end                                                          # end
+          RUBY
+        else
+          class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+            def #{method}(...)           # def example(...)
+              #{accessor}.#{method}(...) #   foo.example(...)
+            end                          # end
+          RUBY
+        end
       end
     end
   end

--- a/spec/rubocop/simple_forwardable_spec.rb
+++ b/spec/rubocop/simple_forwardable_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::SimpleForwardable do
+  let(:delegator) do
+    Class.new do
+      attr_reader :target
+
+      def initialize
+        @target = Struct.new(:foo).new
+      end
+
+      extend RuboCop::SimpleForwardable
+
+      def_delegators :target, :foo=, :foo
+    end
+  end
+
+  it 'correctly delegates to writer methods' do
+    d = delegator.new
+    d.foo = 123
+    expect(d.foo).to eq(123)
+  end
+end


### PR DESCRIPTION
Fix #360

This is a syntax error:
```
def foo=(...)
end
```

So it must use `public_send` instead in that case. It's caused by https://github.com/rubocop/rubocop-ast/blob/47e0eead4b84c3d28d7251a548e152f914219773/lib/rubocop/ast/node/mixin/collection_node.rb#L9-L10

By default the `Array` class doesn't contain such methods but when something like spring is in use, code can be evaluated before rubocop.

I thought about simply rejecting such methods but supporting it is easy enough