### PR TITLE
Fix current Rubocop offenses

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -685,7 +685,7 @@ module RuboCop
       def case_if_value_used?
         # (case <condition> <when...>)
         # (if <condition> <truebranch> <falsebranch>)
-        sibling_index.zero? ? true : parent.value_used?
+        sibling_index.zero? || parent.value_used?
       end
 
       def while_until_value_used?


### PR DESCRIPTION
```
Offenses:

lib/rubocop/ast/node.rb:688:29: C: [Correctable] Style/RedundantCondition: Use double pipes || instead.
        sibling_index.zero? ? true : parent.value_used?
                            ^^^^^^^^

175 files inspected, 1 offense detected, 1 offense autocorrectable
```