### PR TITLE
Add support for `itblock` node for Ruby 3.4

### DIFF
--- a/changelog/new_support_itblock.md
+++ b/changelog/new_support_itblock.md
@@ -1,0 +1,1 @@
+* [#365](https://github.com/rubocop/rubocop-ast/pull/365): Add support for `itblock` node for Ruby 3.4. ([@earlopain][])

--- a/docs/modules/ROOT/pages/node_types.adoc
+++ b/docs/modules/ROOT/pages/node_types.adoc
@@ -170,6 +170,8 @@ The following fields are given when relevant to nodes in the source code:
 
 |numblock|Block that has numbered arguments (`_1`) referenced inside it.|Three children. First child is a `send`/`csend` node representing the way the block is created, second child is an `int` (the number of numeric arguments) and the third child is a body statement.|proc { _1 + _3 }|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/BlockNode[BlockNode]
 
+|itblock|Block that has the `it` block parameter referenced inside it.|Three children. First child is a `send`/`csend` node representing the way the block is created, second child is the symbol `it` and the third child is a body statement.|proc { it }|N/A
+
 |op_asgn|Operator-assignment - perform an operation and assign the value.|Three children. First child must be an assignment node, second child is the operator (e.g. `:+`) and the third child is the expression node.|a += b|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/OpAsgnNode[OpAsgnNode]
 
 |optarg|Optional positional argument. Must come inside an `args`.|One child - a symbol, representing the argument name.|def foo(bar=1)|https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/ArgNode[ArgNode]

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -32,6 +32,7 @@ module RuboCop
         gvasgn:              AsgnNode,
         block:               BlockNode,
         numblock:            BlockNode,
+        itblock:             BlockNode,
         break:               BreakNode,
         case_match:          CaseMatchNode,
         casgn:               CasgnNode,

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -112,7 +112,8 @@ module RuboCop
         csend: :call,
 
         block: :any_block,
-        numblock: :any_block
+        numblock: :any_block,
+        itblock: :any_block
       }.freeze
       private_constant :GROUP_FOR_TYPE
 

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -11,6 +11,8 @@ module RuboCop
     class BlockNode < Node
       include MethodIdentifierPredicates
 
+      IT_BLOCK_ARGUMENT = [ArgNode.new(:arg, [:it])].freeze
+      private_constant :IT_BLOCK_ARGUMENT
       VOID_CONTEXT_METHODS = %i[each tap].freeze
       private_constant :VOID_CONTEXT_METHODS
 
@@ -46,10 +48,10 @@ module RuboCop
       #
       # @return [Array<Node>]
       def arguments
-        if numblock_type?
-          [].freeze # Numbered parameters have no block arguments.
-        else
+        if block_type?
           node_parts[1]
+        else
+          [].freeze # Numblocks and itblocks have no explicit block arguments.
         end
       end
 
@@ -60,6 +62,8 @@ module RuboCop
       def argument_list
         if numblock_type?
           numbered_arguments
+        elsif itblock_type?
+          IT_BLOCK_ARGUMENT
         else
           arguments.argument_list
         end
@@ -153,10 +157,7 @@ module RuboCop
 
       private
 
-      # Numbered arguments of this `numblock`.
       def numbered_arguments
-        return [].freeze unless numblock_type?
-
         max_param = children[1]
         1.upto(max_param).map do |i|
           ArgNode.new(:arg, [:"_#{i}"])

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -39,10 +39,10 @@ module RuboCop
         end
       end
 
-      # The `block` or `numblock` node associated with this method dispatch, if any.
+      # The `block`, `numblock`, or `itblock` node associated with this method dispatch, if any.
       #
-      # @return [BlockNode, nil] the `block` or `numblock` node associated with this method
-      #                          call or `nil`
+      # @return [BlockNode, nil] the `block`, `numblock`, or `itblock` node associated with this
+      #                          method call or `nil`
       def block_node
         parent if block_literal?
       end

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -159,6 +159,7 @@ module RuboCop
       def_callback :if, :always, :nil?, :nil?
       def_callback :block, :always, :always, :nil?
       def_callback :numblock, :always, :skip, :nil?
+      def_callback :itblock, :always, :skip, :nil?
       def_callback :defs, :always, :skip, :always, :nil?
 
       def_callback %i[send csend], body: <<~RUBY
@@ -176,7 +177,7 @@ module RuboCop
 
       to_define = ::Parser::Meta::NODE_TYPES.to_a
       to_define -= defined
-      to_define -= %i[numargs ident] # transient
+      to_define -= %i[numargs itarg ident] # transient
       to_define -= %i[blockarg_expr restarg_expr] # obsolete
       to_define -= %i[objc_kwarg objc_restarg objc_varargs] # mac_ruby
       def_callback to_define, body: <<~RUBY

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.add_dependency('parser', '>= 3.3.1.0')
+  s.add_dependency('parser', '>= 3.3.7.2')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end

--- a/spec/rubocop/ast/block_node_spec.rb
+++ b/spec/rubocop/ast/block_node_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe RuboCop::AST::BlockNode do
         it { expect(block_node.arguments).to be_empty }
       end
     end
+
+    context '>= Ruby 3.4', :ruby34, broken_on: :parser do
+      context 'using `it` block parameter' do
+        let(:source) { 'foo { it }' }
+
+        it { expect(block_node.arguments).to be_empty }
+      end
+    end
   end
 
   describe '#argument_list' do
@@ -79,6 +87,14 @@ RSpec.describe RuboCop::AST::BlockNode do
 
           it { expect(names).to eq(%i[_1 _2]) }
         end
+      end
+    end
+
+    context '>= Ruby 3.4', :ruby34, broken_on: :parser do
+      context 'using `it` block parameter' do
+        let(:source) { 'foo { it }' }
+
+        it { expect(names).to eq(%i[it]) }
       end
     end
   end
@@ -117,6 +133,14 @@ RSpec.describe RuboCop::AST::BlockNode do
     context '>= Ruby 2.7', :ruby27 do
       context 'using numbered parameters' do
         let(:source) { 'foo { _1 }' }
+
+        it { is_expected.not_to be_arguments }
+      end
+    end
+
+    context '>= Ruby 3.4', :ruby34 do
+      context 'using `it` block parameter' do
+        let(:source) { 'foo { it }' }
 
         it { is_expected.not_to be_arguments }
       end
@@ -337,6 +361,14 @@ RSpec.describe RuboCop::AST::BlockNode do
     context '>= Ruby 2.7', :ruby27 do
       context 'using numbered parameters' do
         let(:source) { 'foo { _1 }' }
+
+        it { expect(block_node.first_argument).to be_nil }
+      end
+    end
+
+    context '>= Ruby 3.4', :ruby34 do
+      context 'using `it` block parameter' do
+        let(:source) { 'foo { it }' }
 
         it { expect(block_node.first_argument).to be_nil }
       end

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -491,6 +491,40 @@ RSpec.describe RuboCop::AST::Node do
         end
       end
     end
+
+    context 'using Ruby >= 3.4', :ruby34 do
+      context 'class definition with an itblock' do
+        let(:src) { 'Class.new { do_something(it) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'module definition with an itblock' do
+        let(:src) { 'Module.new { do_something(it) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'Struct definition with an itblock' do
+        let(:src) { 'Struct.new(:foo, :bar) { do_something(it) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+
+      context 'Data definition with an itblock' do
+        let(:src) { 'Data.define(:foo, :bar) { do_something(it) }' }
+
+        it 'matches' do
+          expect(node).to be_class_constructor
+        end
+      end
+    end
   end
 
   describe '#struct_constructor?' do

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -206,6 +206,21 @@ RSpec.describe RuboCop::AST::SendNode do
         it { expect(send_node).to be_bare_access_modifier }
       end
     end
+
+    context 'with Ruby >= 3.4', :ruby34 do
+      context 'when node is access modifier in itblock' do
+        let(:source) do
+          <<~RUBY
+            included do
+            it
+            >> module_function <<
+            end
+          RUBY
+        end
+
+        it { expect(send_node).to be_bare_access_modifier }
+      end
+    end
   end
 
   describe '#non_bare_access_modifier?' do
@@ -332,6 +347,19 @@ RSpec.describe RuboCop::AST::SendNode do
             ['concern :Auth do',
              '>>bar :baz<<',
              '  bar _1',
+             'end'].join("\n")
+          end
+
+          it { expect(send_node).to be_macro }
+        end
+      end
+
+      context 'with Ruby >= 3.4', :ruby27 do
+        context 'when parent is an itblock in a macro scope' do
+          let(:source) do
+            ['concern :Auth do',
+             '>>bar :baz<<',
+             '  bar it',
              'end'].join("\n")
           end
 
@@ -1106,6 +1134,14 @@ RSpec.describe RuboCop::AST::SendNode do
         it { expect(send_node).to be_block_literal }
       end
     end
+
+    context 'with Ruby >= 3.4', :ruby27 do
+      context 'with an itblock literal' do
+        let(:source) { '>> foo.bar << { baz(it) }' }
+
+        it { expect(send_node).to be_block_literal }
+      end
+    end
   end
 
   describe '#arithmetic_operation?' do
@@ -1152,6 +1188,14 @@ RSpec.describe RuboCop::AST::SendNode do
         let(:source) { '>>foo.bar<< { baz(_1) }' }
 
         it { expect(send_node.block_node).to be_numblock_type }
+      end
+    end
+
+    context 'with Ruby >= 3.4', :ruby34, broken_on: :parser do
+      context 'with an itblock literal' do
+        let(:source) { '>>foo.bar<< { baz(it) }' }
+
+        it { expect(send_node.block_node).to be_itblock_type }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,7 +64,8 @@ RSpec.shared_context 'ruby 3.3', :ruby33 do
 end
 
 RSpec.shared_context 'ruby 3.4', :ruby34 do
-  let(:ruby_version) { 3.4 }
+  # Parser supports parsing Ruby <= 3.3.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : 3.3 }
 end
 
 # ...
@@ -129,6 +130,7 @@ RSpec.configure do |config|
   end
 
   config.filter_run_excluding broken_on: :prism if ENV['PARSER_ENGINE'] == 'parser_prism'
+  config.filter_run_excluding broken_on: :parser if ENV['PARSER_ENGINE'] != 'parser_prism'
 
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
In tests, prism will always be used for Ruby 3.4+ and tests that don't pass with `parser` get marked as broken.

Needs https://github.com/whitequark/parser/pull/1071, draft for now. The minimum parser version _must_ be bumped in this PR, as otherwise `itblock_type?` method is not available.