### PR TITLE
Revert "Don't show a deprecation warning for `EnsureNode#branch` just yet"

### DIFF
--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -6,11 +6,24 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `ensure` nodes within RuboCop.
     class EnsureNode < Node
+      DEPRECATION_WARNING_LOCATION_CACHE = [] # rubocop:disable Style/MutableConstant
+      private_constant :DEPRECATION_WARNING_LOCATION_CACHE
+
       # Returns the body of the `ensure` clause.
       #
       # @return [Node, nil] The body of the `ensure`.
       # @deprecated Use `EnsureNode#branch`
       def body
+        first_caller = caller(1..1).first
+
+        unless DEPRECATION_WARNING_LOCATION_CACHE.include?(first_caller)
+          warn '`EnsureNode#body` is deprecated and will be changed in the next major version of ' \
+               'rubocop-ast. Use `EnsureNode#branch` instead to get the body of the `ensure` branch.'
+          warn "Called from:\n#{caller.join("\n")}\n\n"
+
+          DEPRECATION_WARNING_LOCATION_CACHE << first_caller
+        end
+
         branch
       end
 


### PR DESCRIPTION
Adds the deprecation warning for `EnsureNode#branch` back now that it's fixed in @rubocop, as suggested by @Earlopain.

This is the next step in being able to merge #336.

Reverts rubocop/rubocop-ast#339
See https://github.com/rubocop/rubocop-ast/pull/339#issuecomment-2737067996