### PR TITLE
Stop using `Parser::CurrentRuby`

### DIFF
--- a/lib/rubocop/ast/node_pattern/compiler/debug.rb
+++ b/lib/rubocop/ast/node_pattern/compiler/debug.rb
@@ -109,14 +109,7 @@ module RuboCop
             private
 
             def ruby_ast(ruby)
-              buffer = ::Parser::Source::Buffer.new('(ruby)', source: ruby)
-              ruby_parser.parse(buffer)
-            end
-
-            def ruby_parser
-              require 'parser/current'
-              builder = ::RuboCop::AST::Builder.new
-              ::Parser::CurrentRuby.new(builder)
+              ProcessedSource.new(ruby, RUBY_VERSION.to_f, '(ruby)').ast
             end
           end
 

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
-require 'parser/current'
-
 RSpec.describe RuboCop::AST::NodePattern do
   include RuboCop::AST::Sexp
 
   def parse(code)
-    buffer = Parser::Source::Buffer.new('(string)', 1, source: code)
-    builder = RuboCop::AST::Builder.new
-    Parser::CurrentRuby.new(builder).parse(buffer)
+    RuboCop::AST::ProcessedSource.new(code, ruby_version, '(string)').ast
   end
 
+  let(:ruby_version) { 3.3 }
   let(:root_node) { parse(ruby) }
   let(:node) { root_node }
   let(:params) { [] }


### PR DESCRIPTION
It emits a deprecation warning on Ruby 3.4 and won't support new versions. Instead:
* In tests use a fixed version that can be changed if needed
* Delegate to `ProcessedSource` and `RUBY_VERSION` to do the right thing. Eventually this will use the prism translation automatically