### PR TITLE
Support `Prism::Translation::Parser35` for Ruby 3.5 parser

### DIFF
--- a/changelog/new_support_ruby35.md
+++ b/changelog/new_support_ruby35.md
@@ -1,0 +1,1 @@
+* [#370](https://github.com/rubocop/rubocop-ast/pull/370):  Support `Prism::Translation::Parser35` for Ruby 3.5 parser (experimental). ([@earlopain][], [@koic][])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -109,9 +109,13 @@ for the `:prism_result` keyword argument. Otherwise, the source code is parsed.
 
 [source,ruby]
 ----
-# Using the Parser gem with `prism_result: nil` is the default, meaning the source code is parsed.
+# Using the Parser gem with `prism_result: nil` is the default, meaning the source code is parsed until `ruby_version` is 3.4.
 ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism, prism_result: :prism_result)
 ----
+
+IMPORTANT: The Parser gem supports syntax up to Ruby 3.3, but it does not support syntax in Ruby 3.4,
+such as `it` block parameters. Additionally, there are no plans to support Ruby 3.5 or later.
+For Ruby 3.5 and later, `parser_engine: parser_prism` is chosen automatically.
 
 This is an experimental feature. If you encounter any incompatibilities between
 Prism and the Parser gem, please check the following URL:

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     shared_examples 'invalid parser_engine' do
       it 'raises ArgumentError' do
         expect { processed_source }.to raise_error(ArgumentError) do |e|
-          expected =  'The keyword argument `parser_engine` accepts `parser_whitequark` ' \
-                      "or `parser_prism`, but `#{parser_engine}` was passed."
-          expect(e.message).to eq(expected)
+          expected = 'The keyword argument `parser_engine` accepts .*, ' \
+                     "but `#{parser_engine}` was passed."
+          expect(e.message).to match(expected)
         end
       end
     end
@@ -69,11 +69,55 @@ RSpec.describe RuboCop::AST::ProcessedSource do
 
     context 'when using `parser_engine: :parser_prism` and `prism_result` with a `ParseLexResult`' do
       let(:ruby_version) { 3.4 }
-      let(:parser_prism) { :parser_prism }
+      let(:parser_engine) { :parser_prism }
       let(:prism_result) { prism_parse_lex_result }
 
       it 'returns an instance of ProcessedSource' do
         is_expected.to be_a(described_class)
+      end
+    end
+
+    context 'when `parser_engine` is `parser_whitequark`' do
+      let(:parser_engine) { :parser_whitequark }
+
+      context 'and Ruby 3.4 is requested' do
+        let(:ruby_version) { 3.4 }
+
+        it 'uses `parser_whitequark`' do
+          expect(processed_source.parser_engine).to eq(:parser_whitequark)
+        end
+      end
+    end
+
+    context 'when `parser_engine` is `parser_prism`' do
+      let(:parser_engine) { :parser_prism }
+
+      context 'and Ruby 3.3 is requested' do
+        let(:ruby_version) { 3.3 }
+
+        it 'uses `parser_prism`' do
+          expect(processed_source.parser_engine).to eq(:parser_prism)
+        end
+      end
+    end
+
+    context 'when `parser_engine` is `:default`' do
+      let(:parser_engine) { :default }
+
+      context 'and Ruby 3.4 is requested' do
+        let(:ruby_version) { 3.4 }
+
+        it 'uses `parser_whitequark`' do
+          expect(processed_source.parser_engine).to eq(:parser_whitequark)
+        end
+      end
+
+      context 'and Ruby 3.5 is requested' do
+        let(:ruby_version) { 3.5 }
+
+        it 'uses `parser_prism`' do
+          expect(processed_source.parser_engine).to eq(:parser_prism)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,11 @@ RSpec.shared_context 'ruby 3.4', :ruby34 do
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : 3.3 }
 end
 
+RSpec.shared_context 'ruby 3.5', :ruby35 do
+  # Parser supports parsing Ruby <= 3.3.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.5 : 3.3 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
One step further towards https://github.com/rubocop/rubocop/issues/13617

In RuboCop, the parser engine in the default config can be set to `default`, and  with Ruby 3.5, RuboCop will then automatically choose prism to do its job.

More discussion and considerations in https://github.com/rubocop/rubocop-ast/pull/371

