### PR TITLE
Support `Prism::Translation::Parser35` for Ruby 3.5 parser

### DIFF
--- a/changelog/new_support_ruby35.md
+++ b/changelog/new_support_ruby35.md
@@ -1,0 +1,1 @@
+* [#371](https://github.com/rubocop/rubocop-ast/pull/371):Support `Prism::Translation::Parser35` for Ruby 3.5 parser (experimental). ([@koic][])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -109,9 +109,13 @@ for the `:prism_result` keyword argument. Otherwise, the source code is parsed.
 
 [source,ruby]
 ----
-# Using the Parser gem with `prism_result: nil` is the default, meaning the source code is parsed.
+# Using the Parser gem with `prism_result: nil` is the default, meaning the source code is parsed until `ruby_version` is 3.4.
 ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism, prism_result: :prism_result)
 ----
+
+The Parser gem supports syntax up to Ruby 3.3, but it does not support syntax in Ruby 3.4,
+such as `it` block parameters. Additionally, there are no plans to support Ruby 3.5 or later.
+From Ruby 3.5, only `parser_engine: parser_prism` may be supported by default.
 
 This is an experimental feature. If you encounter any incompatibilities between
 Prism and the Parser gem, please check the following URL:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,6 +68,11 @@ RSpec.shared_context 'ruby 3.4', :ruby34 do
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.4 : 3.3 }
 end
 
+RSpec.shared_context 'ruby 3.5', :ruby35 do
+  # Parser supports parsing Ruby <= 3.3.
+  let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.5 : 3.3 }
+end
+
 # ...
 module DefaultRubyVersion
   extend RSpec::SharedContext


### PR DESCRIPTION
## Summary

`Prism::Translation::Parser35` has been started development for Ruby 3.5 (edge Ruby): https://github.com/ruby/prism/pull/3346

At present, there is no timeline for Ruby 3.5 support in the Parser gem: https://github.com/whitequark/parser/issues/1046

Given this, support for Ruby 3.5 will first be introduced in `Prism::Translation::Parser`. This can also serve as a trigger to facilitate user migration from `ParserEngine: parser_whitequark` to `ParserEngine: parser_prism`.

As for Ruby 3.4, `Prism::Translation::Parser` is working on supporting the `it` syntax in https://github.com/ruby/prism/pull/3481, but the Parser gem has not yet supported for it. However, whether to deprecate Ruby 3.4 in the Parser gem will be considered separately from this PR.

Since Ruby 3.5 is a development version with minimal impact on users, while Ruby 3.4 is a stable release, they will be evaluated separately.

## Additional Information

First, the default `parser_engine` for Ruby 3.5 is set to `parser_prism`. This default aligns with the current state of support, as the Parser gem is not expected to support Ruby 3.5.

The more challenging decision is how to handle the default for Ruby 3.4. Ruby 3.4 will likely serve as a transition period between the Parser gem and Prism. While it is possible to set the default `parser_engine` to `parser_prism` for Ruby 3.4 as well, considering the potential unexpected incompatibilities in `Prism::Translation::Parser`, the default remains `parser_whitequark`.

In any case, the primary use case is RuboCop, and what matters most is which value RuboCop chooses to pass. In other words, the key decision lies with RuboCop.