### PR TITLE
Remove prism skips in tests

### DIFF
--- a/spec/rubocop/ast/fixtures/code_examples.rb
+++ b/spec/rubocop/ast/fixtures/code_examples.rb
@@ -719,9 +719,6 @@ unless foo then bar; else baz; end
 unless foo; bar; else baz; end
 
 #----
-proc {_1 = nil}
-
-#----
 begin ensure end
 
 #----
@@ -904,24 +901,6 @@ foo, bar = 1, 2
 
 #----
 foo, bar, baz = 1, 2
-
-#----
-proc {_1 = nil}
-
-#----
-_2 = 1
-
-#----
-proc {|_3|}
-
-#----
-def x(_4) end
-
-#----
-def _5; end
-
-#----
-def self._6; end
 
 #----
 meth rescue bar
@@ -1125,25 +1104,7 @@ bar def foo; self.each do end end
 case foo; in "a": then true; end
 
 #----
-case foo; in "#{ 'a' }": then true; end
-
-#----
-case foo; in "#{ %q{a} }": then true; end
-
-#----
-case foo; in "#{ %Q{a} }": then true; end
-
-#----
 case foo; in "a": 1 then true; end
-
-#----
-case foo; in "#{ 'a' }": 1 then true; end
-
-#----
-case foo; in "#{ %q{a} }": 1 then true; end
-
-#----
-case foo; in "#{ %Q{a} }": 1 then true; end
 
 #----
 a&.b &&= 1
@@ -1416,9 +1377,6 @@ f{ |a, b,| }
 
 #----
 p begin 1.times do 1 end end
-
-#----
-retry
 
 #----
 p <<~E

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
-RSpec.describe RuboCop::AST::IfNode, broken_on: :prism do
+RSpec.describe RuboCop::AST::IfNode do
   subject(:if_node) { parse_source(source).ast }
 
   describe '.new' do

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -269,9 +269,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
       end
     end
 
-    # FIXME: `broken_on: :prism` can be removed when
-    # https://github.com/ruby/prism/issues/2454 will be released.
-    context 'when the source is valid but has some warning diagnostics', broken_on: :prism do
+    context 'when the source is valid but has some warning diagnostics' do
       let(:source) { 'do_something *array' }
 
       it 'returns true' do
@@ -527,8 +525,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
   end
   # rubocop:enable RSpec/RedundantPredicateMatcher
 
-  # FIXME: https://github.com/ruby/prism/issues/2467
-  describe '#preceding_line', broken_on: :prism do
+  describe '#preceding_line' do
     let(:source) { <<~RUBY }
       [ line, 1 ]
       { line: 2 }
@@ -544,8 +541,7 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     end
   end
 
-  # FIXME: https://github.com/ruby/prism/issues/2467
-  describe '#following_line', broken_on: :prism do
+  describe '#following_line' do
     let(:source) { <<~RUBY }
       [ line, 1 ]
       { line: 2 }

--- a/spec/rubocop/ast/token_spec.rb
+++ b/spec/rubocop/ast/token_spec.rb
@@ -346,9 +346,7 @@ RSpec.describe RuboCop::AST::Token do
       end
 
       describe '#left_brace?' do
-        # FIXME: `broken_on: :prism` can be removed when
-        # https://github.com/ruby/prism/issues/2454 will be released.
-        it 'returns true for left hash brace tokens', broken_on: :prism do
+        it 'returns true for left hash brace tokens' do
           expect(left_hash_brace_token).to be_left_brace
         end
 
@@ -364,9 +362,7 @@ RSpec.describe RuboCop::AST::Token do
           expect(left_lambda_brace_token).to be_left_curly_brace
         end
 
-        # FIXME: `broken_on: :prism` can be removed when
-        # https://github.com/ruby/prism/issues/2454 will be released.
-        it 'returns false for non left block brace tokens', broken_on: :prism do
+        it 'returns false for non left block brace tokens' do
           expect(left_hash_brace_token).not_to be_left_curly_brace
           expect(right_block_brace_token).not_to be_left_curly_brace
         end

--- a/spec/rubocop/ast/traversal_spec.rb
+++ b/spec/rubocop/ast/traversal_spec.rb
@@ -110,8 +110,7 @@ RSpec.describe RuboCop::AST::Traversal do
 
       let(:source) { "foo=bar=baz=nil; #{example}" }
 
-      # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
-      it 'traverses all nodes', broken_on: :prism do
+      it 'traverses all nodes' do
         actual = node.each_node.count
         expect(traverse.hits).to eql(actual)
       end

--- a/spec/rubocop/ast/until_node_spec.rb
+++ b/spec/rubocop/ast/until_node_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe RuboCop::AST::UntilNode do
     it { expect(until_node.inverse_keyword).to eq('while') }
   end
 
-  # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
-  describe '#do?', broken_on: :prism do
+  describe '#do?' do
     context 'with a do keyword' do
       let(:source) { 'until foo do; bar; end' }
 

--- a/spec/rubocop/ast/while_node_spec.rb
+++ b/spec/rubocop/ast/while_node_spec.rb
@@ -30,8 +30,7 @@ RSpec.describe RuboCop::AST::WhileNode do
   end
 
   describe '#do?' do
-    # FIXME: `broken_on: :prism` can be removed when Prism > 0.24.0 will be released.
-    context 'with a do keyword', broken_on: :prism do
+    context 'with a do keyword' do
       let(:source) { 'while foo do; bar; end' }
 
       it { is_expected.to be_do }


### PR DESCRIPTION
These all just pass now.

The traversal spec is a bit special. With `parser`, Ruby 2.7 is used but `prism` can only do 3.3. So some code samples are now invalid syntax on newer rubies. I simply removed those.