### PR TITLE
Add `prism` as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gemspec
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'oedipus_lex', '>= 2.6.0', require: false
-gem 'prism', '>= 1.1.0'
 gem 'racc'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'

--- a/changelog/change_prism_runtime_dep.md
+++ b/changelog/change_prism_runtime_dep.md
@@ -1,0 +1,1 @@
+* [#373](https://github.com/rubocop/rubocop-ast/pull/373): Add `prism` as a runtime dependency. ([@earlopain])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -83,40 +83,21 @@ rule = MyRule.new
 source.ast.each_node { |n| rule.process(n) }
 ----
 
-In RuboCop AST, you can specify Prism as the parser engine backend.
-
-If running through Bundler, please first add `gem 'prism'` to your Gemfile:
-
-[source,ruby]
-----
-gem 'prism'
-----
-
-By specifying `parser_engine: :parser_prism`, parsing with Prism can be processed:
-
-[source,ruby]
-----
-# Using the Parser gem with `parser_engine: parser_whitequark` is the default.
-ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism)
-----
-
-Furthermore, by passing an instance of `Prism::ParseLexResult` to the `:prism_result` keyword argument,
-the Prism parsing process can be bypassed. This is a useful API for Ruby LSP, where `Prism::ParseLexResult` has
+If you have already parsed the Ruby code with `prism`, you can pass an instance of `Prism::ParseLexResult`
+to the `:prism_result` keyword argument. This is a useful API for Ruby LSP, where `Prism::ParseLexResult` has
 already been obtained externally from RuboCop. A `Prism::ParseLexResult` instance is a value that can be obtained,
 for example, as the return value of `Prism.parse_lex(source)`.
-The bypass occurs only when `parser_engine: :parser_prism` is set and an instance of `Prism::ParseLexResult` is specified
+The bypass occurs only when the source is processed by prism and an instance of `Prism::ParseLexResult` is specified
 for the `:prism_result` keyword argument. Otherwise, the source code is parsed.
 
 [source,ruby]
 ----
-# Using the Parser gem with `prism_result: nil` is the default, meaning the source code is parsed until `ruby_version` is 3.4.
-ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism, prism_result: :prism_result)
+# `parser_prism` is chosen automatically for `ruby_version >= 3.5` but you can also request
+# it explicitly starting from `ruby_version` 3.3. Requesting `parser_prism` for an earlier version
+# will raise an error.
+ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism, prism_result: parse_lex_result)
 ----
 
 IMPORTANT: The Parser gem supports syntax up to Ruby 3.3, but it does not support syntax in Ruby 3.4,
 such as `it` block parameters. Additionally, there are no plans to support Ruby 3.5 or later.
 For Ruby 3.5 and later, `parser_engine: parser_prism` is chosen automatically.
-
-This is an experimental feature. If you encounter any incompatibilities between
-Prism and the Parser gem, please check the following URL:
-https://github.com/ruby/prism/issues?q=is%3Aissue+is%3Aopen+label%3Arubocop

--- a/lib/rubocop/ast.rb
+++ b/lib/rubocop/ast.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'parser'
+require 'prism'
 require 'forwardable'
 require 'set'
 
@@ -92,6 +93,7 @@ require_relative 'ast/node/when_node'
 require_relative 'ast/node/while_node'
 require_relative 'ast/node/yield_node'
 require_relative 'ast/builder'
+require_relative 'ast/builder_prism'
 require_relative 'ast/processed_source'
 require_relative 'ast/rubocop_compatibility'
 require_relative 'ast/token'

--- a/rubocop-ast.gemspec
+++ b/rubocop-ast.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   }
 
   s.add_dependency('parser', '>= 3.3.7.2')
+  s.add_dependency('prism', '~> 1.4')
 
   ##### Do NOT add `rubocop` (or anything depending on `rubocop`) here. See Gemfile
 end

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'prism'
-
 RSpec.describe RuboCop::AST::ProcessedSource do
   subject(:processed_source) do
     described_class.new(


### PR DESCRIPTION
RuboCop is starting to rely on it to parse ruby versions that the parser gem doesn't support.
This absolves the user from declaring the dependency themselves.

Bits and pieces I removed from https://github.com/rubocop/rubocop-ast/pull/370