### PR TITLE
Use the prism translation layer to analyze Ruby 3.4 by default 

### DIFF
--- a/changelog/change_prism_ruby_3.4.md
+++ b/changelog/change_prism_ruby_3.4.md
@@ -1,0 +1,1 @@
+* [#374](https://github.com/rubocop/rubocop-ast/pull/374): Use the `prism` translation layer to analyze Ruby 3.4 by default. ([@earlopain])

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -92,7 +92,7 @@ for the `:prism_result` keyword argument. Otherwise, the source code is parsed.
 
 [source,ruby]
 ----
-# `parser_prism` is chosen automatically for `ruby_version >= 3.5` but you can also request
+# `parser_prism` is chosen automatically for `ruby_version >= 3.4` but you can also request
 # it explicitly starting from `ruby_version` 3.3. Requesting `parser_prism` for an earlier version
 # will raise an error.
 ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser_prism, prism_result: parse_lex_result)
@@ -100,4 +100,4 @@ ProcessedSource.new(@options[:stdin], ruby_version, file, parser_engine: :parser
 
 IMPORTANT: The Parser gem supports syntax up to Ruby 3.3, but it does not support syntax in Ruby 3.4,
 such as `it` block parameters. Additionally, there are no plans to support Ruby 3.5 or later.
-For Ruby 3.5 and later, `parser_engine: parser_prism` is chosen automatically.
+For Ruby 3.4 and later, `parser_engine: parser_prism` is chosen automatically.

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -381,7 +381,7 @@ module RuboCop
       # It is also not fully compatible with Ruby 3.4 but for
       # now respects using parser for backwards compatibility.
       def default_parser_engine(ruby_version)
-        if ruby_version >= 3.5
+        if ruby_version >= 3.4
           :parser_prism
         else
           :parser_whitequark

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -102,16 +102,16 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     context 'when `parser_engine` is `:default`' do
       let(:parser_engine) { :default }
 
-      context 'and Ruby 3.4 is requested' do
-        let(:ruby_version) { 3.4 }
+      context 'and Ruby 3.3 is requested' do
+        let(:ruby_version) { 3.3 }
 
         it 'uses `parser_whitequark`' do
           expect(processed_source.parser_engine).to eq(:parser_whitequark)
         end
       end
 
-      context 'and Ruby 3.5 is requested' do
-        let(:ruby_version) { 3.5 }
+      context 'and Ruby 3.4 is requested' do
+        let(:ruby_version) { 3.4 }
 
         it 'uses `parser_prism`' do
           expect(processed_source.parser_engine).to eq(:parser_prism)


### PR DESCRIPTION
The parser gem doesn't actually support any of the Ruby 3.4 syntax changes.

Builds on top of https://github.com/rubocop/rubocop-ast/pull/373