### PR TITLE
Use a fixed version of racc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 gem 'bump', require: false
 gem 'bundler', '>= 1.15.0', '< 3.0'
 gem 'oedipus_lex', '>= 2.6.0', require: false
-gem 'racc'
+gem 'racc', '1.8.1'
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.7'
 gem 'simplecov', '~> 0.20'


### PR DESCRIPTION
The gem contains files generated via it and I noticed that the most recent release used 1.8.1, while the one before was created with 1.5.0

There are some differences in the generated files. It seems best to always use an explicit version, similar to how it's done in the `parser` gem. https://github.com/whitequark/parser/pulls?q=is%3Apr+racc