### PR TITLE
Add support `RuboCop::AST::Node#any_def_type?` method

### DIFF
--- a/changelog/new_support_any_def_type_predicate.md
+++ b/changelog/new_support_any_def_type_predicate.md
@@ -1,0 +1,1 @@
+* [#377](https://github.com/rubocop/rubocop-ast/pull/377): Support `RuboCop::AST::Node#any_def_type?` method. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -87,6 +87,9 @@ module RuboCop
 
       # @api private
       GROUP_FOR_TYPE = {
+        def: :any_def,
+        defs: :any_def,
+
         arg: :argument,
         optarg: :argument,
         restarg: :argument,
@@ -511,6 +514,10 @@ module RuboCop
 
       def argument?
         parent&.send_type? && parent.arguments.include?(self)
+      end
+
+      def any_def_type?
+        GROUP_FOR_TYPE[type] == :any_def
       end
 
       def argument_type?

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -200,8 +200,7 @@ module RuboCop
         arg = node.children[2]
 
         return unless node.send_type? && node.receiver.nil? && arg.is_a?(::AST::Node)
-
-        return arg if arg.type?(:def, :defs)
+        return arg if arg.any_def_type?
 
         def_modifier(arg)
       end
@@ -271,7 +270,7 @@ module RuboCop
 
       # @!method adjacent_def_modifier?(node = self)
       def_node_matcher :adjacent_def_modifier?, <<~PATTERN
-        (send nil? _ ({def defs} ...))
+        (send nil? _ (any_def ...))
       PATTERN
 
       # @!method bare_access_modifier_declaration?(node = self)


### PR DESCRIPTION
This PR adds support for `RuboCop::AST::Node#any_def_type?` method, which abstracts over the `def` and `defs` node types.