### PR TITLE
Fix `RuboCop::AST::NumericNode#sign?` to return boolean

### DIFF
--- a/changelog/fix_numeric_node_sign_to_return_boolean.md
+++ b/changelog/fix_numeric_node_sign_to_return_boolean.md
@@ -1,0 +1,1 @@
+* [#380](https://github.com/rubocop/rubocop-ast/pull/380): Fix `RuboCop::AST::NumericNode#sign?` to return boolean. ([@viralpraxis][])

--- a/lib/rubocop/ast/node/mixin/numeric_node.rb
+++ b/lib/rubocop/ast/node/mixin/numeric_node.rb
@@ -15,7 +15,7 @@ module RuboCop
       #
       # @return [Boolean] whether this literal has a sign.
       def sign?
-        source.match(SIGN_REGEX)
+        source.match?(SIGN_REGEX)
       end
     end
   end

--- a/spec/rubocop/ast/float_node_spec.rb
+++ b/spec/rubocop/ast/float_node_spec.rb
@@ -10,16 +10,18 @@ RSpec.describe RuboCop::AST::FloatNode do
   end
 
   describe '#sign?' do
+    subject { float_node.sign? }
+
     context 'explicit positive float' do
       let(:source) { '+42.0' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
 
     context 'explicit negative float' do
       let(:source) { '-42.0' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
   end
 

--- a/spec/rubocop/ast/int_node_spec.rb
+++ b/spec/rubocop/ast/int_node_spec.rb
@@ -10,16 +10,18 @@ RSpec.describe RuboCop::AST::IntNode do
   end
 
   describe '#sign?' do
+    subject { int_node.sign? }
+
     context 'explicit positive int' do
       let(:source) { '+42' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
 
     context 'explicit negative int' do
       let(:source) { '-42' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
   end
 

--- a/spec/rubocop/ast/rational_node_spec.rb
+++ b/spec/rubocop/ast/rational_node_spec.rb
@@ -10,16 +10,18 @@ RSpec.describe RuboCop::AST::RationalNode do
   end
 
   describe '#sign?' do
+    subject { rational_node.sign? }
+
     context 'when explicit positive rational' do
       let(:source) { '+0.2r' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
 
     context 'when explicit negative rational' do
       let(:source) { '-0.2r' }
 
-      it { is_expected.to be_sign }
+      it { is_expected.to be(true) }
     end
   end
 


### PR DESCRIPTION
The documentation states that `sign?` returns boolean:

```ruby
# Checks whether this is literal has a sign.
#
# @example
#
#   +42
#
# @return [Boolean] whether this literal has a sign.
def sign?
  source.match(SIGN_REGEX)
end
```

but it does not.

Looks like the only usage [1] of `sign?` is this [2] module, so nothing should break.

[1] https://github.com/search?q=org%3Arubocop%20sign%3F&type=code
[2] https://github.com/rubocop/rubocop/blob/ddbb2a1bb65a29ac2d2d963196f7b00821779fd6/lib/rubocop/cop/style/method_call_with_args_parentheses/omit_parentheses.rb#L226