### PR TITLE
Support `AST::Node#any_match_pattern_type?` method

### DIFF
--- a/changelog/new_add_any_match_pattern_type_p_to_ast_node.md
+++ b/changelog/new_add_any_match_pattern_type_p_to_ast_node.md
@@ -1,0 +1,1 @@
+* [#381](https://github.com/rubocop/rubocop-ast/pull/381): Support `AST::Node#any_match_pattern_type?` method. ([@koic][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -116,7 +116,10 @@ module RuboCop
 
         block: :any_block,
         numblock: :any_block,
-        itblock: :any_block
+        itblock: :any_block,
+
+        match_pattern: :any_match_pattern,
+        match_pattern_p: :any_match_pattern
       }.freeze
       private_constant :GROUP_FOR_TYPE
 
@@ -538,6 +541,10 @@ module RuboCop
 
       def any_block_type?
         GROUP_FOR_TYPE[type] == :any_block
+      end
+
+      def any_match_pattern_type?
+        GROUP_FOR_TYPE[type] == :any_match_pattern
       end
 
       def guard_clause?

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1083,6 +1083,53 @@ RSpec.describe RuboCop::AST::Node do
     end
   end
 
+  describe '#any_match_pattern_type?' do
+    # Ruby 2.7's one-line `in` pattern node type is `match-pattern`.
+    context 'when `in` one-line pattern matching', :ruby27 do
+      let(:src) { 'expression in pattern' }
+
+      it 'is true' do
+        if node.in_match_type?
+          skip "`in_match` from `AST::Builder.modernize` isn't treated as one-line pattern matching."
+        end
+
+        expect(node).to be_any_match_pattern_type
+      end
+    end
+
+    # Ruby 3.0's one-line `in` pattern node type is `match-pattern-p`.
+    context 'when `in` one-line pattern matching', :ruby30 do
+      let(:src) { 'expression in pattern' }
+
+      it 'is true' do
+        expect(node).to be_any_match_pattern_type
+      end
+    end
+
+    # Ruby 3.0's one-line `=>` pattern node type is `match-pattern`.
+    context 'when `=>` one-line pattern matching', :ruby30 do
+      let(:src) { 'expression => pattern' }
+
+      it 'is true' do
+        expect(node).to be_any_match_pattern_type
+      end
+    end
+
+    context 'when pattern matching', :ruby27 do
+      let(:src) do
+        <<~RUBY
+          case expression
+          in pattern
+          end
+        RUBY
+      end
+
+      it 'is false' do
+        expect(node).not_to be_any_match_pattern_type
+      end
+    end
+  end
+
   describe '#type?' do
     let(:src) do
       <<~RUBY


### PR DESCRIPTION
This PR adds `AST::Node#any_match_pattern_type?`.

This method can be used to simplify multiple places where `node.type?(:match_pattern, :match_pattern_p)` is used, such as in the changes made in https://github.com/rubocop/rubocop/pull/14224.