### PR TITLE
Fix an error when using Parser gem with `prism_result`

### DIFF
--- a/changelog/fix_an_error_when_using_parser_gem_with_prism_result.md
+++ b/changelog/fix_an_error_when_using_parser_gem_with_prism_result.md
@@ -1,0 +1,1 @@
+* [#382](https://github.com/rubocop/rubocop-ast/pull/382): Fix an error when using Parser gem with `prism_result`. ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -341,7 +341,7 @@ module RuboCop
 
         parser_class = parser_class(ruby_version, parser_engine)
 
-        parser_instance = if prism_result
+        parser_instance = if parser_engine == :parser_prism && prism_result
                             # NOTE: Since it is intended for use with Ruby LSP, it targets only Prism.
                             # If there is no reuse of a pre-parsed result, such as in Ruby LSP,
                             # regular parsing with Prism occurs, and `else` branch will be executed.


### PR DESCRIPTION
This PR fixes an error when using Parser gem with `prism_result`. https://github.com/rubocop/rubocop/actions/runs/15497886582/job/43638843391?pr=14251

Since Ruby LSP 0.24 or later, `prism_result` is now passed as a `Prism::ParseLexResult`. As a result, the following build error occurs in RuboCop for the Ruby LSP add-on.

The processing that uses `prism_result` assumes Prism and cannot be performed when using the Parser gem.