### PR TITLE
Remove CodeClimate from CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -28,11 +28,9 @@ jobs:
       matrix:
         os: [ubuntu]
         ruby: [2.7, "3.0", 3.1, 3.2, 3.3, 3.4, head]
-        coverage: [null]
         modern: [null]
         title: [null]
         include:
-          - { ruby: 2.7, os: ubuntu, coverage: true, title: "Coverage" }
           - { ruby: "3.0", os: ubuntu, modern: true, title: 'Specs "modern"' }
           - { ruby: jruby, os: ubuntu }
           - { ruby: jruby-head, os: ubuntu }
@@ -45,15 +43,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: code coverage
-        if: matrix.coverage
-        uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: "758a8228862932dc8afa9144c4a5bc5dfe29c2f7dde1b7734175bad49ee310e7"
-          COVERAGE: "true"
-        with:
-          coverageCommand: bundle exec rake spec
-          debug: true
       - name: set modernize mode
         if: matrix.modern == true
         run: echo 'MODERNIZE=true' >> $GITHUB_ENV
@@ -61,7 +50,6 @@ jobs:
         if: matrix.os != 'windows'
         run: (! bundle exec rubocop -h 2> /dev/null) && echo 'RuboCop successfully *not* loaded for local tests'
       - name: spec
-        if: "matrix.coverage != true"
         run: bundle exec rake spec
 
   prism:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/rubocop-ast.svg)](https://badge.fury.io/rb/rubocop-ast)
 [![CI](https://github.com/rubocop/rubocop-ast/actions/workflows/rubocop.yml/badge.svg)](https://github.com/rubocop/rubocop-ast/actions/workflows/rubocop.yml)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/a29666e6373bc41bc0a9/test_coverage)](https://codeclimate.com/github/rubocop/rubocop-ast/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/a29666e6373bc41bc0a9/maintainability)](https://codeclimate.com/github/rubocop/rubocop-ast/maintainability)
 
 Contains the classes needed by [RuboCop](https://github.com/rubocop/rubocop) to deal with Ruby's AST, in particular:
 


### PR DESCRIPTION
CodeClimate as a coverage service has been discontinued.

https://codeclimate.com/blog/code-climate-quality-is-now-qlty-software
https://docs.qlty.sh/migration/coverage
> The Code Climate API will be disabled on July 18th, 2025.

In RuboCop, the coverage recording was simply removed instead of setting up an alternative. Can we do the same here? Also see https://github.com/rubocop/rubocop/issues/14392