### PR TITLE
Allow to match against the empty string

### DIFF
--- a/changelog/fix_nodepattern_empty_string.md
+++ b/changelog/fix_nodepattern_empty_string.md
@@ -1,0 +1,1 @@
+* [#386](https://github.com/rubocop/rubocop-ast/pull/386): Fix parsing of node patterns that match against the empty string. ([@earloapin][])

--- a/lib/rubocop/ast/node_pattern/lexer.rex
+++ b/lib/rubocop/ast/node_pattern/lexer.rex
@@ -21,7 +21,7 @@ macros
 rules
         /\s+/
         /:(#{SYMBOL_NAME})/o      { emit :tSYMBOL, &:to_sym }
-        /"(.+?)"/                 { emit :tSTRING }
+        /"(.*?)"/                 { emit :tSTRING }
         /[-+]?\d+\.\d+/           { emit :tNUMBER, &:to_f }
         /[-+]?\d+/                { emit :tNUMBER, &:to_i }
         /#{Regexp.union(

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -232,6 +232,13 @@ RSpec.describe RuboCop::AST::NodePattern do
       it { expect(pattern).to match_code(node) }
     end
 
+    context 'empty string literals' do
+      let(:pattern) { '(str "")' }
+      let(:ruby) { '""' }
+
+      it { expect(pattern).to match_code(node) }
+    end
+
     context 'symbol literals' do
       let(:pattern) { '(sym :foo)' }
       let(:ruby) { ':foo' }


### PR DESCRIPTION
You can work around this by writing `(str empty?)` instead but I feel like this should just work

cc @zopolis4