### PR TITLE
Add `Node#any_sym_type?` to match `sym` and `dsym` types

### DIFF
--- a/changelog/new_add_nodeany_sym_type_to_match_sym_and.md
+++ b/changelog/new_add_nodeany_sym_type_to_match_sym_and.md
@@ -1,0 +1,1 @@
+* [#387](https://github.com/rubocop/rubocop-ast/pull/387): Add `Node#any_sym_type?` to match `sym` and `dsym` types. ([@dvandersluis][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -112,6 +112,9 @@ module RuboCop
         dstr: :any_str,
         xstr: :any_str,
 
+        sym: :any_sym,
+        dsym: :any_sym,
+
         irange: :range,
         erange: :range,
 
@@ -553,6 +556,10 @@ module RuboCop
 
       def any_str_type?
         GROUP_FOR_TYPE[type] == :any_str
+      end
+
+      def any_sym_type?
+        GROUP_FOR_TYPE[type] == :any_sym
       end
 
       def guard_clause?

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1164,6 +1164,56 @@ RSpec.describe RuboCop::AST::Node do
     end
   end
 
+  describe '#any_sym_type?' do
+    context 'when symbol' do
+      let(:src) { ':str' }
+
+      it 'is true' do
+        expect(node).to be_any_sym_type
+      end
+    end
+
+    context 'when interpolated symbol' do
+      let(:src) { ':"#{foo}"' }
+
+      it 'is true' do
+        expect(node).to be_any_sym_type
+      end
+    end
+
+    context 'when string' do
+      let(:src) { "'foo'" }
+
+      it 'is false' do
+        expect(node).not_to be_any_sym_type
+      end
+    end
+
+    context 'when interpolated string' do
+      let(:src) { %q("foo #{bar}") }
+
+      it 'is false' do
+        expect(node).not_to be_any_sym_type
+      end
+    end
+
+    context 'when `xstr` node' do
+      let(:src) { '`ls`' }
+
+      it 'is false' do
+        expect(node).not_to be_any_sym_type
+      end
+    end
+
+    context 'when numeric literal' do
+      let(:src) { '42' }
+
+      it 'is false' do
+        expect(node).not_to be_any_sym_type
+      end
+    end
+  end
+
   describe '#type?' do
     let(:src) do
       <<~RUBY


### PR DESCRIPTION
Following #328, adds `any_sym_type?` to match `sym` and `dsym` nodes.