### PR TITLE
Minor performance improvements

### DIFF
--- a/changelog/fix_avoid_intermediate_array_allocations_in.md
+++ b/changelog/fix_avoid_intermediate_array_allocations_in.md
@@ -1,0 +1,1 @@
+- [#401](https://github.com/rubocop/rubocop-ast/pull/401): Avoid intermediate array allocations in HashNode#each_key/each_value. ([@bbastov][])

--- a/changelog/fix_fix_force_encoding_being_a_noop_for.md
+++ b/changelog/fix_fix_force_encoding_being_a_noop_for.md
@@ -1,0 +1,1 @@
+- [#401](https://github.com/rubocop/rubocop-ast/pull/401): Fix force_encoding being a no-op for frozen string inputs. ([@bbastov][])

--- a/lib/rubocop/ast/node/hash_node.rb
+++ b/lib/rubocop/ast/node/hash_node.rb
@@ -56,10 +56,10 @@ module RuboCop
       #
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
-      def each_key(&block)
-        return pairs.map(&:key).to_enum unless block
+      def each_key
+        return to_enum(__method__) unless block_given?
 
-        pairs.map(&:key).each(&block)
+        each_child_node(:pair) { |pair| yield pair.key }
 
         self
       end
@@ -80,10 +80,10 @@ module RuboCop
       #
       # @return [self] if a block is given
       # @return [Enumerator] if no block is given
-      def each_value(&block)
-        return pairs.map(&:value).to_enum unless block
+      def each_value
+        return to_enum(__method__) unless block_given?
 
-        pairs.map(&:value).each(&block)
+        each_child_node(:pair) { |pair| yield pair.value }
 
         self
       end

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -99,7 +99,7 @@ module RuboCop
         # Defaults source encoding to UTF-8, regardless of the encoding it has
         # been read with, which could be non-utf8 depending on the default
         # external encoding.
-        (+source).force_encoding(Encoding::UTF_8) unless source.encoding == Encoding::UTF_8
+        source = (+source).force_encoding(Encoding::UTF_8) unless source.encoding == Encoding::UTF_8
 
         @raw_source = source
         @path = path


### PR DESCRIPTION
## Summary

* **Fix `ProcessedSource` `force_encoding` for frozen string inputs** — `(+source).force_encoding(...)` was creating a mutable copy but discarding the result, so the encoding fix was silently a no-op when a frozen string was passed. Now assigns the result back.
* **Avoid intermediate array allocations in `HashNode#each_key`/`#each_value`** — the old implementation called `pairs.map(&:key).each(&block)`, allocating a full intermediate array on every call. Now yields directly from `each_child_node`.

## Benchmark results

```
--- HashNode#each_key ---
  each_key (current):  1055691.9 i/s
  each_key (old):       625038.9 i/s - 1.69x slower

--- HashNode#each_value ---
  each_value (current):  1076484.9 i/s
  each_value (old):       591610.7 i/s - 1.82x slower

--- Allocation counts (100 calls) ---
  each_key: old=1301 allocs, new=600 allocs
```