### PR TITLE
Use Prism by default for Ruby 3.3 analysis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/change_use_prism_by_default_for_ruby_33.md
+++ b/changelog/change_use_prism_by_default_for_ruby_33.md
@@ -1,0 +1,1 @@
+* [#405](https://github.com/rubocop/rubocop-ast/pull/405): Use Prism by default when analyzing Ruby 3.3 code. ([@bbatsov][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -378,11 +378,11 @@ module RuboCop
         end
       end
 
-      # The Parser gem does not support Ruby 3.5 or later.
-      # It is also not fully compatible with Ruby 3.4 but for
-      # now respects using parser for backwards compatibility.
+      # Prism is used for all Ruby versions it can parse (3.3 and later);
+      # the Parser gem does not support Ruby 3.5 or later and is not fully
+      # compatible with Ruby 3.4.
       def default_parser_engine(ruby_version)
-        if ruby_version >= 3.4
+        if ruby_version >= 3.3
           :parser_prism
         else
           :parser_whitequark

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -102,11 +102,19 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     context 'when `parser_engine` is `:default`' do
       let(:parser_engine) { :default }
 
-      context 'and Ruby 3.3 is requested' do
-        let(:ruby_version) { 3.3 }
+      context 'and Ruby 3.2 is requested' do
+        let(:ruby_version) { 3.2 }
 
         it 'uses `parser_whitequark`' do
           expect(processed_source.parser_engine).to eq(:parser_whitequark)
+        end
+      end
+
+      context 'and Ruby 3.3 is requested' do
+        let(:ruby_version) { 3.3 }
+
+        it 'uses `parser_prism`' do
+          expect(processed_source.parser_engine).to eq(:parser_prism)
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
Currently `parser_engine: :default` resolves to Prism only for target Ruby 3.4+, and 3.3 still goes through the Parser gem. That boundary made sense when the translation layer was fresh, but Prism parses as 3.3 just fine (`Prism::Translation::Parser33`), it's about 2x faster than whitequark on the ProcessedSource level, and the compatibility issue tail has been quiet for a while. Both rubocop-ast suites and RuboCop's entire spec suite pass with the flip.

Anyone who needs the old behavior can still set `parser_engine: :parser_whitequark` explicitly, and RuboCop exposes that via `ParserEngine`.

Related: #404, and longer term I'd like us to move to a native prism builder so the translation layer can be dropped entirely.