### PR TITLE
Fix offenses flagged by RuboCop master

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
CI's Coding Style job runs against RuboCop master, which recently gained `InternalAffairs/LocationLineEqualityComparison` and tightened redundant-disable detection, so every PR is currently red on that job. The new cop suggests `same_line?`, which is a RuboCop-side helper not available here, so it gets disabled like the other InternalAffairs cops whose suggestions don't apply to rubocop-ast. The `Style/OneClassPerFile` disable in spec_helper is simply no longer needed.

Same commit is already cherry-picked into #404 and #405; merging this first unblocks CI for everything else.