### PR TITLE
Fix the enumerator form of the deprecated each_* branch methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/fix_enumerator_form_of_deprecated_branch_methods.md
+++ b/changelog/fix_enumerator_form_of_deprecated_branch_methods.md
@@ -1,0 +1,1 @@
+* [#407](https://github.com/rubocop/rubocop-ast/pull/407): Fix the blockless form of the deprecated `each_when`, `each_in_pattern`, `each_condition`, and `each_branch` methods, which returned an unusable `Enumerator`. ([@bbatsov][])

--- a/lib/rubocop/ast/node/case_match_node.rb
+++ b/lib/rubocop/ast/node/case_match_node.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       # @deprecated Use `in_pattern_branches.each`
       def each_in_pattern(&block)
-        return in_pattern_branches.to_enum(__method__) unless block
+        return to_enum(__method__) unless block
 
         in_pattern_branches.each(&block)
 

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       # @deprecated Use `when_branches.each`
       def each_when(&block)
-        return when_branches.to_enum(__method__) unless block
+        return to_enum(__method__) unless block
 
         when_branches.each(&block)
 

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -169,7 +169,7 @@ module RuboCop
 
       # @deprecated Use `branches.each`
       def each_branch(&block)
-        return branches.to_enum(__method__) unless block
+        return to_enum(__method__) unless block
 
         branches.each(&block)
       end

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -15,7 +15,7 @@ module RuboCop
 
       # @deprecated Use `conditions.each`
       def each_condition(&block)
-        return conditions.to_enum(__method__) unless block
+        return to_enum(__method__) unless block
 
         conditions.each(&block)
 

--- a/spec/rubocop/ast/case_match_node_spec.rb
+++ b/spec/rubocop/ast/case_match_node_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe RuboCop::AST::CaseMatchNode do
         it {
           expect(case_match_node.each_in_pattern).to be_a(Enumerator)
         }
+
+        it {
+          expect(case_match_node.each_in_pattern.to_a).to eq(case_match_node.in_pattern_branches)
+        }
       end
 
       context 'when passed a block' do

--- a/spec/rubocop/ast/case_node_spec.rb
+++ b/spec/rubocop/ast/case_node_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe RuboCop::AST::CaseNode do
 
     context 'when not passed a block' do
       it { expect(case_node.each_when).to be_a(Enumerator) }
+
+      it { expect(case_node.each_when.to_a).to eq(case_node.when_branches) }
     end
 
     context 'when passed a block' do

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -516,6 +516,8 @@ RSpec.describe RuboCop::AST::IfNode do
 
     context 'when not passed a block' do
       it { expect(if_node.each_branch).to be_a(Enumerator) }
+
+      it { expect(if_node.each_branch.to_a).to eq(if_node.branches) }
     end
 
     context 'when passed a block' do

--- a/spec/rubocop/ast/when_node_spec.rb
+++ b/spec/rubocop/ast/when_node_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe RuboCop::AST::WhenNode do
 
     context 'when not passed a block' do
       it { expect(when_node.each_condition).to be_a(Enumerator) }
+
+      it { expect(when_node.each_condition.to_a).to eq(when_node.conditions) }
     end
 
     context 'when passed a block' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
The blockless form of `each_when`, `each_in_pattern`, `each_condition` and `each_branch` called `to_enum` on the branches array instead of the node, so the returned enumerator raised `NoMethodError` the moment you iterated it. Broken since 2020 apparently, which tells you how popular these deprecated methods are, but they're still shipped API (and RuboCop's `Lint/Void` still uses the block form), so they should work until 2.0 removes them.

The existing specs only asserted `be_a(Enumerator)` without ever iterating, which is exactly how this hid; they now consume the enumerator too.

Includes the same lint-fix commit as #406 so CI is green; merging #406 first makes it disappear here.