### PR TITLE
Small ProcessedSource fixes

### DIFF
--- a/changelog/change_memoize_checksum_and_skip_redundant_token_sort.md
+++ b/changelog/change_memoize_checksum_and_skip_redundant_token_sort.md
@@ -1,0 +1,1 @@
+* [#408](https://github.com/rubocop/rubocop-ast/pull/408): Memoize `ProcessedSource#checksum` and skip the token sort when the tokens are already in order. ([@bbatsov][])

--- a/changelog/fix_preceding_line_for_first_line_tokens.md
+++ b/changelog/fix_preceding_line_for_first_line_tokens.md
@@ -1,0 +1,1 @@
+* [#408](https://github.com/rubocop/rubocop-ast/pull/408): Fix `ProcessedSource#preceding_line` returning the last line of the file for tokens on the first line. ([@bbatsov][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -144,7 +144,7 @@ module RuboCop
 
       # Raw source checksum for tracking infinite loops.
       def checksum
-        Digest::SHA1.hexdigest(@raw_source)
+        @checksum ||= Digest::SHA1.hexdigest(@raw_source)
       end
 
       # @deprecated Use `comments.each`
@@ -217,6 +217,8 @@ module RuboCop
       end
 
       def preceding_line(token)
+        return nil if token.line < 2
+
         lines[token.line - 2]
       end
 
@@ -266,11 +268,22 @@ module RuboCop
       # is passed as a method argument. In this case tokens are interleaved by
       # heredoc contents' tokens.
       def sorted_tokens
-        # Use stable sort.
-        @sorted_tokens ||= tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
+        # Most sources have their tokens already in order, in which case
+        # sorting can be skipped entirely. Callers only ever read from the
+        # returned array, so it is safe to reuse `tokens` as is.
+        @sorted_tokens ||= if tokens_sorted?
+                             tokens
+                           else
+                             # Use stable sort.
+                             tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
+                           end
       end
 
       private
+
+      def tokens_sorted?
+        tokens.each_cons(2).all? { |a, b| a.begin_pos <= b.begin_pos }
+      end
 
       # `__END__` only starts a data section when it isn't nested inside a
       # string or heredoc, which is what the last token's line disambiguates.

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -597,6 +597,21 @@ RSpec.describe RuboCop::AST::ProcessedSource do
   end
   # rubocop:enable RSpec/RedundantPredicateMatcher
 
+  describe '#checksum' do
+    let(:source) { <<~RUBY }
+      def some_method
+      end
+    RUBY
+
+    it 'returns the SHA1 checksum of the raw source' do
+      expect(processed_source.checksum).to eq Digest::SHA1.hexdigest(source)
+    end
+
+    it 'memoizes the checksum' do
+      expect(processed_source.checksum).to equal(processed_source.checksum)
+    end
+  end
+
   describe '#preceding_line' do
     let(:source) { <<~RUBY }
       [ line, 1 ]
@@ -610,6 +625,11 @@ RSpec.describe RuboCop::AST::ProcessedSource do
 
       comment_token = processed_source.find_token(&:comment?)
       expect(processed_source.preceding_line(comment_token)).to eq '{ line: 2 }'
+    end
+
+    it 'returns nil for a token on the first line' do
+      bracket_token = processed_source.find_token(&:left_bracket?)
+      expect(processed_source.preceding_line(bracket_token)).to be_nil
     end
   end
 
@@ -711,6 +731,35 @@ RSpec.describe RuboCop::AST::ProcessedSource do
     it 'accepts Node as an argument' do
       node = ast.children[1]
       expect(processed_source.last_token_of(node).text).to eq('baz')
+    end
+  end
+
+  describe '#sorted_tokens' do
+    let(:source) { <<~RUBY }
+      foo(1, 2)
+      bar(3)
+    RUBY
+
+    it 'returns tokens sorted by begin position' do
+      positions = processed_source.sorted_tokens.map(&:begin_pos)
+      expect(positions).to eq positions.sort
+    end
+
+    context 'when heredoc as argument is present' do
+      let(:source) { <<~RUBY }
+        foo(1, [before], <<~DOC, [after])
+          inside heredoc.
+        DOC
+        bar(2)
+      RUBY
+
+      it 'returns tokens sorted by begin position' do
+        expect(processed_source.tokens.map(&:begin_pos))
+          .not_to eq processed_source.tokens.map(&:begin_pos).sort
+
+        positions = processed_source.sorted_tokens.map(&:begin_pos)
+        expect(positions).to eq positions.sort
+      end
     end
   end
 end


### PR DESCRIPTION
Three small independent fixes:

* `checksum` recomputed the SHA1 on every call even though the source never changes after construction; RuboCop calls it once per autocorrect iteration. Now memoized.
* `sorted_tokens` allocated a tuple per token to sort a list that's already ordered for everything except heredoc-argument files. It now checks order first (allocation-free) and only sorts when needed.
* `preceding_line` for a token on line 1 did `lines[-1]` and silently returned the last line of the file. It returns nil now.

Includes the lint-fix commit from #406 for green CI.