### PR TITLE
Use identity comparison in chained? and block_literal?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/fix_chained_and_block_literal_identity.md
+++ b/changelog/fix_chained_and_block_literal_identity.md
@@ -1,0 +1,1 @@
+* [#409](https://github.com/rubocop/rubocop-ast/pull/409): Fix `Node#chained?` and `MethodDispatchNode#block_literal?` returning `true` for nodes that are merely structurally equal to the receiver or send node (e.g. the argument in `foo.bar(foo)`). ([@bbatsov][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -519,7 +519,7 @@ module RuboCop
       end
 
       def chained?
-        parent&.call_type? && eql?(parent.receiver)
+        parent&.call_type? && equal?(parent.receiver)
       end
 
       def argument?

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -165,7 +165,7 @@ module RuboCop
       #
       # @return [Boolean] whether the dispatched method has a block
       def block_literal?
-        parent&.any_block_type? && eql?(parent.send_node)
+        parent&.any_block_type? && equal?(parent.send_node)
       end
 
       # Checks whether this node is an arithmetic operation

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -379,6 +379,36 @@ RSpec.describe RuboCop::AST::Node do
     end
   end
 
+  describe '#chained?' do
+    context 'when the node is the receiver of a method call' do
+      let(:src) { 'foo.bar.baz' }
+
+      it 'is true' do
+        expect(node.receiver).to be_chained
+      end
+    end
+
+    context 'when the node is an argument structurally equal to the receiver' do
+      let(:src) { 'foo.bar(foo)' }
+
+      it 'is false for the argument' do
+        expect(node.first_argument).not_to be_chained
+      end
+
+      it 'is true for the receiver' do
+        expect(node.receiver).to be_chained
+      end
+    end
+
+    context 'when the node has no parent' do
+      let(:src) { 'foo' }
+
+      it 'is false' do
+        expect(node).not_to be_chained
+      end
+    end
+  end
+
   describe '#argument_type?' do
     context 'block arguments' do
       let(:src) { 'bar { |a, b = 42, *c, d: 42, **e| nil }' }

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -1127,6 +1127,14 @@ RSpec.describe RuboCop::AST::SendNode do
       it { expect(send_node).not_to be_block_literal }
     end
 
+    context 'with a block whose body is structurally equal to its send node' do
+      let(:source) { 'foo { foo }' }
+      let(:block_node) { parse_source(source).node }
+
+      it { expect(block_node.send_node).to be_block_literal }
+      it { expect(block_node.body).not_to be_block_literal }
+    end
+
     context 'with Ruby >= 2.7', :ruby27 do
       context 'with a numblock literal' do
         let(:source) { '>> foo.bar << { baz(_1) }' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
`chained?` and `block_literal?` compared with `eql?`, which does deep structural equality, so in `foo.bar(foo)` the argument node claimed to be chained (it deep-equals the receiver), and in `foo { foo }` the block body claimed to be a block literal. Since these predicates ask "am I this specific child of my parent", `equal?` is what's meant, and it's also free instead of a recursive tree comparison on a hot path.

Both regression specs fail against the old code. I checked all callers in rubocop-ast and rubocop; none relied on the structural-equality behavior.

Includes the lint-fix commit from #406 for green CI.