### PR TITLE
Reduce allocations in hot node predicates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/change_reduce_allocations_in_hot_node_predicates.md
+++ b/changelog/change_reduce_allocations_in_hot_node_predicates.md
@@ -1,0 +1,1 @@
+* [#410](https://github.com/rubocop/rubocop-ast/pull/410): Reduce allocations in `keyword?` and the method-name predicates (`predicate_method?`, `bang_method?`, etc.). ([@bbatsov][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -76,6 +76,13 @@ module RuboCop
       OPERATOR_KEYWORDS = %i[and or].to_set.freeze
       # @api private
       SPECIAL_KEYWORDS = %w[__FILE__ __LINE__ __ENCODING__].to_set.freeze
+      # The node types which could have a source matching `SPECIAL_KEYWORDS`:
+      # `__FILE__` parses as `str`, `__LINE__` as `int` and `__ENCODING__` as
+      # `const` (or as their own node types when the builder emits them);
+      # `str` and `sym` also cover word/symbol array elements, string parts
+      # and hash labels spelling out one of these keywords.
+      SPECIAL_KEYWORD_TYPES = %i[str sym int const __FILE__ __LINE__ __ENCODING__].to_set.freeze
+      private_constant :SPECIAL_KEYWORD_TYPES
 
       LITERAL_RECURSIVE_METHODS = (COMPARISON_OPERATORS + %i[* ! <=>]).freeze
       LITERAL_RECURSIVE_TYPES = (OPERATOR_KEYWORDS + COMPOSITE_LITERALS + %i[begin pair]).freeze
@@ -503,7 +510,7 @@ module RuboCop
       end
 
       def special_keyword?
-        SPECIAL_KEYWORDS.include?(source)
+        SPECIAL_KEYWORD_TYPES.include?(type) && SPECIAL_KEYWORDS.include?(source)
       end
 
       def operator_keyword?

--- a/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
+++ b/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
@@ -140,7 +140,7 @@ module RuboCop
       #
       # @return [Boolean] whether the method is an assignment
       def assignment_method?
-        !comparison_method? && method_name.to_s.end_with?('=')
+        !comparison_method? && method_name.end_with?('=')
       end
 
       # Checks whether the method is an enumerator method.
@@ -148,7 +148,7 @@ module RuboCop
       # @return [Boolean] whether the method is an enumerator
       def enumerator_method?
         ENUMERATOR_METHODS.include?(method_name) ||
-          method_name.to_s.start_with?('each_')
+          method_name.start_with?('each_')
       end
 
       # Checks whether the method is an Enumerable method.
@@ -162,14 +162,14 @@ module RuboCop
       #
       # @return [Boolean] whether the method is a predicate method
       def predicate_method?
-        method_name.to_s.end_with?('?')
+        method_name.end_with?('?')
       end
 
       # Checks whether the method is a bang method.
       #
       # @return [Boolean] whether the method is a bang method
       def bang_method?
-        method_name.to_s.end_with?('!')
+        method_name.end_with?('!')
       end
 
       # Checks whether the method is a camel case method,
@@ -177,7 +177,7 @@ module RuboCop
       #
       # @return [Boolean] whether the method is a camel case method
       def camel_case_method?
-        method_name.to_s =~ /\A[A-Z]/
+        method_name.match?(/\A[A-Z]/)
       end
 
       # Checks whether the *explicit* receiver of this node is `self`.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
Two allocation fixes on per-send hot paths:

* The method-name predicates (`assignment_method?`, `enumerator_method?`, `predicate_method?`, `bang_method?`, `camel_case_method?`) converted the method name Symbol to a String on every call. `Symbol#start_with?`/`#end_with?` exist since Ruby 2.7, which is our floor, so the conversions are pointless. `camel_case_method?` now uses `match?` and returns a real boolean instead of `0`/nil; all callers use it in boolean context only.
* `keyword?` sliced the node's source out of the buffer for every node just to check for `__FILE__`/`__LINE__`/`__ENCODING__`, which can only ever appear as a handful of node types. A type check now guards the slice; behavior is bit-for-bit identical, including the quirk that symbol/string literals spelled like special keywords count (verified empirically against the old implementation across the odd cases: `%i[__FILE__]`, dstr parts, hash labels).

Includes the lint-fix commit from #406 for green CI.