### PR TITLE
Don't allocate an array per node visited in filtered traversals

### DIFF
--- a/changelog/change_allocation_free_filtered_traversal.md
+++ b/changelog/change_allocation_free_filtered_traversal.md
@@ -1,0 +1,1 @@
+* [#411](https://github.com/rubocop/rubocop-ast/pull/411): Speed up filtered node traversals (`each_descendant(:send)` etc.) by not allocating an array per visited node, and add the non-splatting `Node#type_in?` predicate. ([@bbatsov][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -179,6 +179,13 @@ module RuboCop
       # Allows specific single node types, as well as "grouped" types
       # (e.g. `:boolean` for `:true` or `:false`)
       def type?(*types)
+        type_in?(types)
+      end
+
+      # Non-splatting variant of `type?`, used by the traversal hot paths to
+      # avoid allocating an array per visited node.
+      # @api private
+      def type_in?(types)
         return true if types.include?(type)
 
         group_type = GROUP_FOR_TYPE[type]
@@ -704,9 +711,16 @@ module RuboCop
       def visit_ancestors(types)
         last_node = self
 
-        while (current_node = last_node.parent)
-          yield current_node if types.empty? || current_node.type?(*types)
-          last_node = current_node
+        if types.empty?
+          while (current_node = last_node.parent)
+            yield current_node
+            last_node = current_node
+          end
+        else
+          while (current_node = last_node.parent)
+            yield current_node if current_node.type_in?(types)
+            last_node = current_node
+          end
         end
       end
 

--- a/lib/rubocop/ast/node/mixin/descendence.rb
+++ b/lib/rubocop/ast/node/mixin/descendence.rb
@@ -60,11 +60,7 @@ module RuboCop
       def each_descendant(*types, &block)
         return to_enum(__method__, *types) unless block
 
-        if types.empty?
-          visit_all_descendants(&block)
-        else
-          visit_descendants_of_types(types, &block)
-        end
+        visit_descendants(types, &block)
 
         self
       end
@@ -99,13 +95,9 @@ module RuboCop
       def each_node(*types, &block)
         return to_enum(__method__, *types) unless block
 
-        if types.empty?
-          yield self
-          visit_all_descendants(&block)
-        else
-          yield self if type_in?(types)
-          visit_descendants_of_types(types, &block)
-        end
+        yield self if types.empty? || type_in?(types)
+
+        visit_descendants(types, &block)
 
         self
       end

--- a/lib/rubocop/ast/node/mixin/descendence.rb
+++ b/lib/rubocop/ast/node/mixin/descendence.rb
@@ -25,7 +25,7 @@ module RuboCop
         children.each do |child|
           next unless child.is_a?(::AST::Node)
 
-          yield child if types.empty? || child.type?(*types)
+          yield child if types.empty? || child.type_in?(types)
         end
 
         self
@@ -60,7 +60,11 @@ module RuboCop
       def each_descendant(*types, &block)
         return to_enum(__method__, *types) unless block
 
-        visit_descendants(types, &block)
+        if types.empty?
+          visit_all_descendants(&block)
+        else
+          visit_descendants_of_types(types, &block)
+        end
 
         self
       end
@@ -95,9 +99,13 @@ module RuboCop
       def each_node(*types, &block)
         return to_enum(__method__, *types) unless block
 
-        yield self if types.empty? || type?(*types)
-
-        visit_descendants(types, &block)
+        if types.empty?
+          yield self
+          visit_all_descendants(&block)
+        else
+          yield self if type_in?(types)
+          visit_descendants_of_types(types, &block)
+        end
 
         self
       end
@@ -105,11 +113,28 @@ module RuboCop
       protected
 
       def visit_descendants(types, &block)
+        if types.empty?
+          visit_all_descendants(&block)
+        else
+          visit_descendants_of_types(types, &block)
+        end
+      end
+
+      def visit_all_descendants(&block)
         children.each do |child|
           next unless child.is_a?(::AST::Node)
 
-          yield child if types.empty? || child.type?(*types)
-          child.visit_descendants(types, &block)
+          yield child
+          child.visit_all_descendants(&block)
+        end
+      end
+
+      def visit_descendants_of_types(types, &block)
+        children.each do |child|
+          next unless child.is_a?(::AST::Node)
+
+          yield child if child.type_in?(types)
+          child.visit_descendants_of_types(types, &block)
         end
       end
     end

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1274,6 +1274,13 @@ RSpec.describe RuboCop::AST::Node do
       end
     end
 
+    context 'when given an array of types via `type_in?`' do
+      it 'behaves like `type?`' do
+        expect(node).to be_type_in(%i[send const lvar])
+        expect(node).not_to be_type_in(%i[if while])
+      end
+    end
+
     context 'when it is not one of the given types' do
       it 'is false' do
         expect(node).not_to be_type(:if, :while, :until)


### PR DESCRIPTION
Filtered traversals (`each_descendant(:send)`, `each_node`, `each_ancestor`, `each_child_node`) called `child.type?(*types)` per visited node, which re-splats the types array into a fresh Array every time, and re-tested `types.empty?` per node although it's invariant for the whole walk. These traversals back every `def_node_search` and hundreds of direct call sites in cops, so it adds up.

This adds `Node#type_in?(types)`, a non-splatting variant of `type?` (which now delegates to it), and splits the descendant/ancestor visits into filtered and unfiltered variants chosen once per walk. `visit_descendants` keeps its old signature as a shim since it's protected API.

Measured on a ~1300-node tree: a filtered walk goes from 1336 allocations to 1 and about 13% faster wall time; the allocation elimination also cuts GC pressure across full runs. Unfiltered walks are unchanged.

Includes the lint-fix commit from #406 for green CI.