### PR TITLE
Use identity comparison in argument?

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,10 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
+InternalAffairs/LocationLineEqualityComparison:
+  Enabled: false
+
+# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/fix_argument_predicate_identity.md
+++ b/changelog/fix_argument_predicate_identity.md
@@ -1,0 +1,1 @@
+* [#412](https://github.com/rubocop/rubocop-ast/pull/412): Fix `Node#argument?` returning `true` for receivers that are structurally equal to an argument (e.g. the receiver in `foo.bar(foo)`). ([@bbatsov][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -523,7 +523,9 @@ module RuboCop
       end
 
       def argument?
-        parent&.send_type? && parent.arguments.include?(self)
+        return false unless parent&.send_type?
+
+        parent.arguments.any? { |argument| argument.equal?(self) }
       end
 
       def any_def_type?

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -117,6 +117,23 @@ RSpec.describe RuboCop::AST::Node do
     end
   end
 
+  describe '#argument?' do
+    let(:src) { 'foo.bar(foo, 1)' }
+
+    it 'is true for an argument of a send node' do
+      argument = node.first_argument
+      expect(argument).to be_argument
+    end
+
+    it 'is false for a receiver that is structurally equal to an argument' do
+      expect(node.receiver).not_to be_argument
+    end
+
+    it 'is false for the send node itself' do
+      expect(node).not_to be_argument
+    end
+  end
+
   describe '#recursive_basic_literal?' do
     shared_examples 'literal' do |source|
       let(:src) { source }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,6 @@ module DefaultRubyVersion
   let(:ruby_version) { ENV['PARSER_ENGINE'] == 'parser_prism' ? 3.3 : 2.4 }
 end
 
-# rubocop:disable Style/OneClassPerFile
 module DefaultParserEngine
   extend RSpec::SharedContext
 
@@ -116,7 +115,6 @@ module ParseSourceHelper
     source
   end
 end
-# rubocop:enable Style/OneClassPerFile
 
 RSpec.configure do |config|
   config.include ParseSourceHelper


### PR DESCRIPTION
Same bug class as #409, this time in `argument?`: `parent.arguments.include?(self)` uses deep structural equality, so in `foo.bar(foo)` the *receiver* claims to be an argument because it deep-equals the actual argument. The predicate means "am I one of these specific child nodes", so it now scans by identity, which also replaces recursive tree comparisons with pointer checks on a per-node hot path.

There were no `argument?` specs at all; the new ones include the receiver regression (fails against the old code).

Includes the lint-fix commit from #406 for green CI.