### PR TITLE
Add same_line?, begins_its_line?, any_descendant? and first_part_of_call_chain

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,10 +26,6 @@ InternalAffairs/LocationExpression:
   Enabled: false
 
 # It cannot be replaced with suggested methods defined by RuboCop AST itself.
-InternalAffairs/LocationLineEqualityComparison:
-  Enabled: false
-
-# It cannot be replaced with suggested methods defined by RuboCop AST itself.
 InternalAffairs/MethodNameEndWith:
   Enabled: false
 

--- a/changelog/new_range_and_node_helpers.md
+++ b/changelog/new_range_and_node_helpers.md
@@ -1,0 +1,1 @@
+* [#413](https://github.com/rubocop/rubocop-ast/pull/413): Add `Range#same_line?`, `Range#begins_its_line?`, `Node#any_descendant?`, and `Node#first_part_of_call_chain`, previously private helpers in RuboCop's `Cop::Util`. ([@bbatsov][])

--- a/lib/rubocop/ast/ext/range.rb
+++ b/lib/rubocop/ast/ext/range.rb
@@ -20,6 +20,37 @@ module RuboCop
         def line_span(exclude_end: false)
           ::Range.new(first_line, last_line, exclude_end)
         end
+
+        # @param [Parser::Source::Range, RuboCop::AST::Node, RuboCop::AST::Token,
+        #   Parser::Source::Comment] other
+        # @return [Boolean] whether this range starts on the same line as `other`
+        def same_line?(other)
+          other_line = if other.respond_to?(:line)
+                         other.line
+                       elsif other.respond_to?(:loc)
+                         other.loc.line
+                       end
+
+          !other_line.nil? && line == other_line
+        end
+
+        # Arbitrarily chosen value, should be enough to cover
+        # the most nested source code in real world projects.
+        MAX_LINE_BEGINS_REGEX_INDEX = 50
+        LINE_BEGINS_REGEX_CACHE = Hash.new do |hash, index|
+          hash[index] = /^\s{#{index}}\S/ if index <= MAX_LINE_BEGINS_REGEX_INDEX
+        end
+        private_constant :MAX_LINE_BEGINS_REGEX_INDEX, :LINE_BEGINS_REGEX_CACHE
+
+        # @return [Boolean] whether this range begins its line, i.e. is preceded
+        #   only by whitespace
+        def begins_its_line?
+          if (regex = LINE_BEGINS_REGEX_CACHE[column])
+            source_line.match?(regex)
+          else
+            source_line.index(/\S/) == column
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -536,6 +536,28 @@ module RuboCop
         parent&.call_type? && equal?(parent.receiver)
       end
 
+      # Returns the receiver at the base of this node's call chain, e.g. the
+      # `if` node for `(cond ? a : b).foo.bar`. Returns `self` for non-call
+      # nodes and `nil` when the chain starts with a receiverless call
+      # (e.g. for `foo.bar.baz`).
+      #
+      # @return [Node, nil] the node at the base of this call chain
+      def first_part_of_call_chain
+        node = self
+
+        while node
+          if node.call_type?
+            node = node.receiver
+          elsif node.any_block_type?
+            node = node.send_node
+          else
+            break
+          end
+        end
+
+        node
+      end
+
       def argument?
         return false unless parent&.send_type?
 

--- a/lib/rubocop/ast/node/block_node.rb
+++ b/lib/rubocop/ast/node/block_node.rb
@@ -130,7 +130,7 @@ module RuboCop
       #
       # @return [Boolean] whether the `block` literal is on a single line
       def single_line?
-        loc.begin.line == loc.end.line
+        loc.begin.same_line?(loc.end)
       end
 
       # Checks whether this is a multiline block. This is overridden here

--- a/lib/rubocop/ast/node/mixin/conditional_node.rb
+++ b/lib/rubocop/ast/node/mixin/conditional_node.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       # @return [Boolean] whether the condition is on a single line
       def single_line_condition?
-        loc.keyword.line == condition.source_range.line
+        loc.keyword.same_line?(condition)
       end
 
       # Checks whether the condition of the node is written on more than

--- a/lib/rubocop/ast/node/mixin/descendence.rb
+++ b/lib/rubocop/ast/node/mixin/descendence.rb
@@ -73,6 +73,31 @@ module RuboCop
         each_descendant.to_a
       end
 
+      # Checks whether any descendant node matches. The types and the optional
+      # block are interpreted the same way as for `each_descendant`.
+      #
+      # @overload any_descendant?
+      #   Checks whether there is any descendant node.
+      # @overload any_descendant?(type, ...)
+      #   Checks whether there is any descendant node matching any of the types.
+      #   @param [Symbol] type a node type
+      # @yieldparam [Node] node descendant nodes matching the types, if a block is given
+      # @return [Boolean] whether any (matching) descendant node was found
+      #   (for which the block returned a truthy value, if given)
+      def any_descendant?(*types)
+        if block_given?
+          each_descendant(*types) do |descendant|
+            return true if yield(descendant)
+          end
+        else
+          each_descendant(*types) do # rubocop:disable Lint/UnreachableLoop
+            return true
+          end
+        end
+
+        false
+      end
+
       # Calls the given block for the receiver and each descendant node in
       # depth-first order.
       # If no block is given, an `Enumerator` is returned.

--- a/spec/rubocop/ast/ext/range_spec.rb
+++ b/spec/rubocop/ast/ext/range_spec.rb
@@ -19,4 +19,73 @@ RSpec.describe RuboCop::AST::Ext::Range do
       expect(node.source_range.line_span(exclude_end: true)).to eq 1...4
     end
   end
+
+  describe '#same_line?' do
+    let(:source) { <<~RUBY }
+      foo(1,
+          2) # comment
+      bar(3)
+    RUBY
+
+    let(:processed_source) { parse_source(source) }
+    let(:foo_node) { processed_source.ast.children.first }
+    let(:bar_node) { processed_source.ast.children.last }
+
+    it 'is true for a range on the same line' do
+      expect(foo_node.source_range).to be_same_line(foo_node.loc.selector)
+    end
+
+    it 'is false for a range on another line' do
+      expect(foo_node.source_range).not_to be_same_line(foo_node.loc.end)
+    end
+
+    it 'accepts a node' do
+      expect(foo_node.source_range).not_to be_same_line(bar_node)
+      expect(bar_node.source_range).to be_same_line(bar_node)
+    end
+
+    it 'accepts a token' do
+      first_token = processed_source.tokens.first
+      expect(foo_node.source_range).to be_same_line(first_token)
+    end
+
+    it 'accepts a comment' do
+      comment = processed_source.comments.first
+      expect(foo_node.loc.end).to be_same_line(comment)
+    end
+
+    it 'compares by the line the range starts on' do
+      expect(foo_node.source_range).not_to be_same_line(foo_node.source_range.end)
+    end
+  end
+
+  describe '#begins_its_line?' do
+    let(:source) { <<~RUBY }
+      foo
+        .bar(1,
+             2)
+    RUBY
+
+    let(:send_node) { parse_source(source).ast }
+
+    it 'is true for a range preceded only by whitespace' do
+      expect(send_node.loc.selector.adjust(begin_pos: -1)).to be_begins_its_line
+    end
+
+    it 'is false for a range preceded by code' do
+      expect(send_node.loc.selector).not_to be_begins_its_line
+    end
+
+    it 'is true for a range at the very start of a line' do
+      expect(send_node.source_range).to be_begins_its_line
+    end
+
+    context 'with indentation deeper than the cached regexps' do
+      let(:source) { "#{' ' * 60}foo\n" }
+
+      it 'is true for a range preceded only by whitespace' do
+        expect(send_node.source_range).to be_begins_its_line
+      end
+    end
+  end
 end

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -1421,5 +1421,54 @@ RSpec.describe RuboCop::AST::Node do
       it_behaves_like 'traverse', 'two arguments', :restarg, :blockarg, %i[restarg blockarg]
       it_behaves_like 'traverse', 'group argument', :argument, %i[arg restarg arg kwrestarg blockarg]
     end
+
+    describe '#any_descendant?' do
+      let(:src) { 'foo(true, bar(baz))' }
+
+      it 'is true when there is any descendant' do
+        expect(node).to be_any_descendant
+      end
+
+      it 'is false for a node without descendants' do
+        expect(node.first_argument).not_to be_any_descendant
+      end
+
+      it 'respects the given types' do
+        expect(node).to be_any_descendant(:true)
+        expect(node).not_to be_any_descendant(:false)
+        expect(node).to be_any_descendant(:false, :boolean)
+      end
+
+      it 'checks the block against the matching descendants' do
+        expect(node).to be_any_descendant(:send, &:arguments?)
+        expect(node).not_to be_any_descendant(:send) { |n| n.method?(:qux) }
+      end
+    end
+  end
+
+  describe '#first_part_of_call_chain' do
+    context 'on a chain of calls and blocks' do
+      let(:src) { '[1, 2].foo.bar { |x| x }.baz' }
+
+      it 'returns the node at the base of the chain' do
+        expect(node.first_part_of_call_chain).to be_array_type
+      end
+    end
+
+    context 'on a chain starting with a receiverless call' do
+      let(:src) { 'foo.bar.baz' }
+
+      it 'returns nil' do
+        expect(node.first_part_of_call_chain).to be_nil
+      end
+    end
+
+    context 'on a non-call node' do
+      let(:src) { '[1, 2]' }
+
+      it 'returns self' do
+        expect(node.first_part_of_call_chain).to equal(node)
+      end
+    end
   end
 end


### PR DESCRIPTION
These four helpers have lived in RuboCop's `Cop::Util` although they're pure AST/range logic, which is why our own `.rubocop.yml` had to disable `InternalAffairs/LocationLineEqualityComparison` with the note that the suggested method doesn't exist in rubocop-ast. Moving them down lets RuboCop and every extension use them, and the cop is re-enabled here since `loc.begin.same_line?(loc.end)` is now expressible (used by `BlockNode#single_line?` and `ConditionalNode#single_line_condition?`).

Placement notes: `same_line?` and `begins_its_line?` go on `Ext::Range` rather than `Node`, deliberately, because `HashElementNode#same_line?` already exists with different semantics (multiline overlap counts as same line) and a `Node#same_line?` would silently diverge for pair nodes. `same_line?` accepts ranges, nodes, tokens, and comments, mirroring `Cop::Util#same_line?`'s duck-typing. `any_descendant?` respects its type arguments in the blockless form (the `Cop::Util` version ignores them there, but nothing calls it that way). `first_part_of_call_chain` keeps the `Cop::Util` behavior exactly, including returning nil for receiverless chains.

Once this is released I'll send the RuboCop-side PR making `Cop::Util` delegate to these.