### PR TITLE
Compile node patterns lazily

### DIFF
--- a/changelog/change_compile_node_patterns_lazily.md
+++ b/changelog/change_compile_node_patterns_lazily.md
@@ -1,0 +1,1 @@
+* [#414](https://github.com/rubocop/rubocop-ast/pull/414): Compile the patterns of `def_node_matcher`/`def_node_search` lazily on first invocation, significantly reducing load time; `NodePattern.lazy_compilation = false` restores compilation at definition time. ([@bbatsov][])

--- a/lib/rubocop/ast/node_pattern.rb
+++ b/lib/rubocop/ast/node_pattern.rb
@@ -26,6 +26,18 @@ module RuboCop
     class NodePattern
       class Invalid < StandardError; end
 
+      # When `true` (the default), methods defined with the `Macros` compile
+      # their pattern on first invocation instead of at definition time.
+      # Compiling the patterns is a significant part of loading a large body
+      # of cops, and most of them are never invoked in a given run.
+      # Note that with lazy compilation an invalid pattern raises
+      # `NodePattern::Invalid` when the method is first called, not when it
+      # is defined; set to `false` to get definition-time errors back.
+      class << self
+        attr_accessor :lazy_compilation
+      end
+      self.lazy_compilation = true
+
       # Helpers for defining methods based on a pattern string
       module Macros
         # Define a method which applies a pattern to an AST node
@@ -36,7 +48,12 @@ module RuboCop
         # If the node matches, and no block is provided, the new method will
         # return the captures, or `true` if there were none.
         def def_node_matcher(method_name, pattern_str, **keyword_defaults)
-          NodePattern.new(pattern_str).def_node_matcher(self, method_name, **keyword_defaults)
+          if NodePattern.lazy_compilation
+            def_node_pattern_method_lazily(:def_node_matcher, method_name, pattern_str,
+                                           keyword_defaults, caller_locations(1, 1).first)
+          else
+            NodePattern.new(pattern_str).def_node_matcher(self, method_name, **keyword_defaults)
+          end
         end
 
         # Define a method which recurses over the descendants of an AST node,
@@ -46,7 +63,41 @@ module RuboCop
         # as soon as it finds a descendant which matches. Otherwise, it will
         # yield all descendants which match.
         def def_node_search(method_name, pattern_str, **keyword_defaults)
-          NodePattern.new(pattern_str).def_node_search(self, method_name, **keyword_defaults)
+          if NodePattern.lazy_compilation
+            def_node_pattern_method_lazily(:def_node_search, method_name, pattern_str,
+                                           keyword_defaults, caller_locations(1, 1).first)
+          else
+            NodePattern.new(pattern_str).def_node_search(self, method_name, **keyword_defaults)
+          end
+        end
+
+        private
+
+        # Defines a stub that compiles the pattern and replaces itself on
+        # first invocation. The compiled method is invoked through the owner's
+        # instance method rather than a regular dispatch, so that overrides
+        # calling `super` keep working.
+        def def_node_pattern_method_lazily(definer, method_name, pattern_str, keyword_defaults,
+                                           location)
+          base = self
+
+          define_method(method_name) do |*args, **kwargs, &block|
+            # Remove the stub before defining the compiled method in its
+            # place, so that no method redefinition warning is emitted.
+            begin
+              base.send(:remove_method, method_name)
+            rescue NameError
+              nil # the method was already compiled concurrently
+            end
+
+            pattern = NodePattern.new(pattern_str)
+            pattern.definition_location = location
+            pattern.public_send(definer, base, method_name, **keyword_defaults)
+
+            base.instance_method(method_name).bind_call(self, *args, **kwargs, &block)
+          end
+
+          method_name
         end
       end
 
@@ -72,6 +123,11 @@ module RuboCop
       end
 
       attr_reader :pattern, :ast, :match_code
+
+      # The location to attribute methods defined from this pattern to, when
+      # it can't be determined from the call stack (e.g. for lazily compiled
+      # patterns). Used by `MethodDefiner`.
+      attr_accessor :definition_location
 
       def_delegators :@compiler, :captures, :named_parameters, :positional_parameters
 

--- a/lib/rubocop/ast/node_pattern/method_definer.rb
+++ b/lib/rubocop/ast/node_pattern/method_definer.rb
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def def_helper(base, method_name, **defaults)
-          location = caller_locations(3, 1).first
+          location = definition_location || caller_locations(3, 1).first
           unless defaults.empty?
             call = :"without_defaults_#{method_name}"
             base.send :define_method, method_name, &wrapping_block(call, **defaults)

--- a/spec/rubocop/ast/node_pattern_spec.rb
+++ b/spec/rubocop/ast/node_pattern_spec.rb
@@ -2290,6 +2290,42 @@ RSpec.describe RuboCop::AST::NodePattern do
             expect { result }.to(raise_argument_error)
           end
         end
+
+        context 'when overridden in a subclass calling super' do
+          it 'matches' do
+            subclass = Class.new(defined_class) do
+              # The override exercises the lazily compiled method through `super`.
+              def my_matcher(node) # rubocop:disable Lint/UselessMethodDefinition
+                super
+              end
+            end
+
+            expect(subclass.new.my_matcher(node)).to be(true)
+          end
+        end
+      end
+
+      context 'with an invalid pattern' do
+        let(:pattern) { '(sym ' }
+        let(:helper_name) { :def_node_matcher }
+
+        it 'raises Invalid when the method is first called, not when it is defined' do
+          expect { call_helper }.not_to raise_error
+          expect { result }.to raise_error(RuboCop::AST::NodePattern::Invalid)
+        end
+
+        context 'when lazy compilation is disabled' do
+          around do |example|
+            described_class.lazy_compilation = false
+            example.run
+          ensure
+            described_class.lazy_compilation = true
+          end
+
+          it 'raises Invalid when the method is defined' do
+            expect { call_helper }.to raise_error(RuboCop::AST::NodePattern::Invalid)
+          end
+        end
       end
 
       context 'def_node_search' do


### PR DESCRIPTION
`def_node_matcher`/`def_node_search` compile their pattern (a racc parse plus codegen, ~0.15ms and ~300 allocations each) at definition time. RuboCop defines ~540 patterns and extensions add hundreds more, so this is a meaningful chunk of boot, paid even for `rubocop --only Style/Foo` runs where almost none of the patterns are ever matched. Measured with RuboCop against this branch: `require "rubocop"` goes from ~370ms to ~270ms.

The macros now define a stub that compiles the pattern and replaces itself on first call. Design notes:

* The stub removes itself before the compiled method is defined, so nothing is emitted under `-w` (RuboCop's spec suite runs with `$VERBOSE` on and caught my first attempt).
* The compiled method is invoked through the owner's `instance_method`, so subclass overrides calling `super` work (spec'd).
* The definition location is captured eagerly in the macro and attached to the compiled method via the new `NodePattern#definition_location`, so backtraces and `caller`-sensitive specs still point at the cop source. The existing spec asserting error backtrace line numbers passes unchanged.
* One observable change: an invalid pattern raises `NodePattern::Invalid` at first call instead of at definition. `NodePattern.lazy_compilation = false` restores definition-time errors for anyone who wants load-time validation (e.g. a plugin's CI).

Both suites, self-lint, and RuboCop's entire spec suite (plus its prism variant) pass against this branch.