### PR TITLE
Make sorted_tokens allocation-free

### DIFF
--- a/changelog/change_allocation_free_sorted_tokens.md
+++ b/changelog/change_allocation_free_sorted_tokens.md
@@ -1,0 +1,1 @@
+* [#415](https://github.com/rubocop/rubocop-ast/pull/415): Reduce allocations in `ProcessedSource#sorted_tokens` to almost none. ([@bbatsov][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -264,25 +264,33 @@ module RuboCop
         sorted_tokens[last_token_index(range_or_node)]
       end
 
-      # The tokens list is always sorted by token position, except for cases when heredoc
-      # is passed as a method argument. In this case tokens are interleaved by
-      # heredoc contents' tokens.
+      # The tokens list is out of order when a heredoc is passed as a method
+      # argument (the heredoc contents' tokens are interleaved) and, more
+      # commonly, whenever the source contains comments, whose tokens the
+      # lexer emits out of band.
       def sorted_tokens
-        # Most sources have their tokens already in order, in which case
-        # sorting can be skipped entirely. Callers only ever read from the
-        # returned array, so it is safe to reuse `tokens` as is.
+        # Callers only ever read from the returned array, so it is safe to
+        # reuse `tokens` as is when it's already in order.
         @sorted_tokens ||= if tokens_sorted?
                              tokens
                            else
-                             # Use stable sort.
-                             tokens.sort_by.with_index { |token, i| [token.begin_pos, i] }
+                             sort_tokens
                            end
       end
 
       private
 
       def tokens_sorted?
-        tokens.each_cons(2).all? { |a, b| a.begin_pos <= b.begin_pos }
+        # `each_cons` allocates an array per pair, which would defeat the
+        # point of checking before sorting.
+        (1...tokens.size).all? { |i| tokens[i - 1].begin_pos <= tokens[i].begin_pos }
+      end
+
+      def sort_tokens
+        # Combine the position and the index into a single integer to get a
+        # stable sort without allocating an array per token for the key.
+        size = tokens.size
+        tokens.sort_by.with_index { |token, i| (token.begin_pos * size) + i }
       end
 
       # `__END__` only starts a data section when it isn't nested inside a


### PR DESCRIPTION
Follow-up to #408, which got two things wrong. The order check used `each_cons`, which allocates an array per pair, defeating its own purpose. And re-profiling showed the already-sorted fast path almost never fires on real code anyway: the lexer emits comment tokens out of band, so any file containing comments has out-of-order tokens and takes the sort. The doc comment claiming heredoc arguments are the only unsorted case was wrong too.

So this makes the actual sort cheap instead: position and index combined into one integer key keeps the sort stable without allocating a tuple per token (overflow would need a multi-GB file). The scan is index-based now as well. Measured on `node.rb` (comments and heredocs both): ~2700 allocations down to 20, identical output verified element-wise.