### PR TITLE
Stop allocating in IfNode branch accessors

### DIFF
--- a/changelog/change_allocation_free_if_node_accessors.md
+++ b/changelog/change_allocation_free_if_node_accessors.md
@@ -1,0 +1,1 @@
+* [#416](https://github.com/rubocop/rubocop-ast/pull/416): Make `IfNode` branch accessors (`condition`, `if_branch`, `else_branch`, `unless?`) allocation-free. ([@bbatsov][])

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -22,7 +22,9 @@ module RuboCop
       #
       # @return [Boolean] whether the node is an `unless` statement
       def unless?
-        keyword == 'unless'
+        # Compare the keyword length to avoid allocating the keyword source;
+        # a non-ternary `if` node's keyword can only be `if`, `elsif` or `unless`.
+        !ternary? && loc.keyword.length == 6
       end
 
       # Checks whether the `if` node has an `then` clause.
@@ -120,7 +122,7 @@ module RuboCop
       # @return [Node] the truthy branch node of the `if` node
       # @return [nil] if the truthy branch is empty
       def if_branch
-        node_parts[1]
+        unless? ? children[2] : children[1]
       end
 
       # Returns the branch of the `if` node that gets evaluated when its
@@ -131,7 +133,7 @@ module RuboCop
       # @return [Node] the falsey branch node of the `if` node
       # @return [nil] when there is no else branch
       def else_branch
-        node_parts[2]
+        unless? ? children[1] : children[2]
       end
 
       # Custom destructuring method. This is used to normalize the branches
@@ -139,13 +141,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `if` statement
       def node_parts
-        if unless?
-          condition, false_branch, true_branch = *self
-        else
-          condition, true_branch, false_branch = *self
-        end
-
-        [condition, true_branch, false_branch]
+        [condition, if_branch, else_branch]
       end
 
       # Returns an array of all the branches in the conditional statement.

--- a/lib/rubocop/ast/node/mixin/conditional_node.rb
+++ b/lib/rubocop/ast/node/mixin/conditional_node.rb
@@ -22,12 +22,12 @@ module RuboCop
         !single_line_condition?
       end
 
-      # Returns the condition of the node. This works together with each node's
-      # custom destructuring method to select the correct part of the node.
+      # Returns the condition of the node. The condition is the first child
+      # for all conditional node types, including normalized `unless` nodes.
       #
       # @return [Node, nil] the condition of the node
       def condition
-        node_parts[0]
+        children[0]
       end
 
       # Returns the body associated with the condition. This works together with


### PR DESCRIPTION
Re-profiling after the last batch showed `IfNode#node_parts` as the biggest remaining source of derived-value allocations (~2.3% of a run's total): `condition`/`if_branch`/`else_branch` each built the three-element array per call, plus `unless?` sliced the keyword source out of the buffer every time, and `if` nodes are everywhere.

The accessors now index `children` directly (with the same `unless` swap), `unless?` compares the keyword length instead of allocating its source (a non-ternary `if` node's keyword can only be `if`, `elsif` or `unless`), and `node_parts` is expressed in terms of the accessors. `ConditionalNode#condition` reads `children[0]`, which holds for every includer since only `IfNode` overrides `node_parts` and even there the condition stays first.

Four thousand accessor calls now allocate once (the first `keyword` comparison); behavior verified identical against the old implementation across if/unless/ternary/modifier/elsif forms, and `IfNode` no longer appears in the allocation profile at all.