### PR TITLE
Fix `ProcessedSource` raising parser internal errors

### DIFF
--- a/changelog/fix_an_error_for_parser_internal_exceptions.md
+++ b/changelog/fix_an_error_for_parser_internal_exceptions.md
@@ -1,0 +1,1 @@
+* [#417](https://github.com/rubocop/rubocop-ast/pull/417): Fix `ProcessedSource` raising parser internal errors (e.g. `RegexpError` for `/\c\xFF/ =~ ''`) instead of recording them as `parser_error`. ([@koic][])

--- a/lib/rubocop/ast/processed_source.rb
+++ b/lib/rubocop/ast/processed_source.rb
@@ -341,6 +341,13 @@ module RuboCop
           # All errors are in diagnostics. No need to handle exception.
           comments = []
           tokens = []
+        rescue StandardError => e
+          # The parser gem may fail on invalid sources with an exception other than `Parser::SyntaxError`
+          # and without a diagnostic, e.g. with `RegexpError` for `/\c\xFF/ =~ ""`. Keep the exception
+          # so that it can be reported instead of crashing the caller.
+          @parser_error = e
+          comments = []
+          tokens = []
         end
 
         ast&.complete!

--- a/spec/rubocop/ast/processed_source_spec.rb
+++ b/spec/rubocop/ast/processed_source_spec.rb
@@ -291,6 +291,18 @@ RSpec.describe RuboCop::AST::ProcessedSource do
           .to include('invalid byte sequence')
       end
     end
+
+    context 'when the parser raises an internal error other than `Parser::SyntaxError`' do
+      let(:source) { '/\c\xFF/ =~ ""' }
+
+      it 'returns the error' do
+        expect(processed_source.parser_error).to be_a(Exception)
+      end
+
+      it 'is not valid syntax' do
+        expect(processed_source).not_to be_valid_syntax
+      end
+    end
   end
 
   describe '#lines' do


### PR DESCRIPTION
The parser gem may fail on invalid sources with an exception other than `Parser::SyntaxError` and without a diagnostic. For example, `/\c\xFF/ =~ ""` raises `RegexpError` (invalid multibyte escape) from the static regexp validation, or `ArgumentError` (invalid byte sequence in UTF-8) from the lexer, depending on the parser engine and version.

`ProcessedSource#tokenize` only rescued `Parser::SyntaxError`, so these exceptions escaped from `ProcessedSource#parse` and crashed the caller. For RuboCop, this aborted the entire run without even telling which file was being inspected.

Such exceptions are now recorded as `parser_error`, the same mechanism already used for `EncodingError` and `Parser::UnknownEncodingInMagicComment` when setting the buffer source. RuboCop then reports them per file as a fatal `Lint/Syntax` offense and continues with the remaining files:

```console
$ rubocop example.rb
example.rb:1:1: F: Lint/Syntax: Invalid byte sequence in utf-8.
```

Fixes rubocop/rubocop#15457.